### PR TITLE
knod: source cleanups

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/kfd_knod.c
+++ b/drivers/gpu/drm/amd/amdkfd/kfd_knod.c
@@ -275,7 +275,6 @@ EXPORT_SYMBOL(__knod_map_mem);
 
 void knod_free_mem(struct knod *knod, struct knod_mem *mem)
 {
-	/* TODO for VRAM */
 	if (mem) {
 		list_del_init(&mem->list);
 		kfd_process_free_gpuvm(mem->mem, knod->process->pdds[0],
@@ -787,7 +786,6 @@ static int knod_alloc_one_queue(struct knod *knod, int idx,
 	qp.ctx_save_restore_area_size = topo_dev->node_props.cwsr_size;
 	qp.ctx_save_restore_area_address = (u64)knod->kaql[idx].ctx->gaddr;
 	qp.queue_address = (u64)knod->kaql[idx].aql->gaddr;
-	/* TODO memory is allocated split. so it is failed validate. */
 	qp.queue_size = knod->kaql[idx].aql->size / 2;
 	qp.write_ptr =
 		(void __user *)((u64)knod->kaql[idx].queue->gaddr + 0x38);

--- a/drivers/gpu/drm/amd/amdkfd/kfd_knod.c
+++ b/drivers/gpu/drm/amd/amdkfd/kfd_knod.c
@@ -70,12 +70,12 @@ LIST_HEAD(ctx_list);
  * a context with enough kaql[]/sdma[] pairs for the worst-case
  * consumer.
  *
- * The value is a high-water mark across all accel types — whichever
+ * The value is a high-water mark across all accel types - whichever
  * consumer asks for the most queue pairs wins; a consumer that needs
  * fewer just leaves the extra pairs unused (a minor, harmless GPU
  * resource waste).
  *
- * Default is 1 when nothing has called the setter — mirrors the
+ * Default is 1 when nothing has called the setter - mirrors the
  * historical single-queue behaviour.
  */
 static int knod_requested_queue_cnt = 1;
@@ -490,7 +490,7 @@ static void knod_init_aql_queue(struct knod *knod, int qid, int idx)
 	amd_queue->legacy_doorbell_lock = 0;
 	amd_queue->read_dispatch_id = 0; /* id is index */
 	amd_queue->read_dispatch_id_field_base_byte_offset = 0x80;
-	/* scratch resource descriptor — use allocated scratch BO address */
+	/* scratch resource descriptor - use allocated scratch BO address */
 	scratch_gaddr = (u32)(knod->kaql[idx].scratch->gaddr & 0xffffffff);
 	amd_queue->scratch_resource_descriptor[0] = scratch_gaddr;
 	scratch_gaddr = (u32)((knod->kaql[idx].scratch->gaddr >> 32) & 0xffff);
@@ -761,7 +761,7 @@ static int knod_alloc_one_queue(struct knod *knod, int idx,
 	knod->signal_eid = 0;
 
 	/* Zero ALL queue-related GPU memory BEFORE creating the HW queue.
-	 * kfd_ioctl_create_queue loads HQD immediately — if the memory
+	 * kfd_ioctl_create_queue loads HQD immediately - if the memory
 	 * contains stale data from a previous session (write/read pointers,
 	 * AQL dispatch packets, doorbell values), the GPU starts processing
 	 * garbage packets and goes to 100%.
@@ -813,7 +813,7 @@ static int knod_alloc_one_queue(struct knod *knod, int idx,
 		queue_signal->queue_ptr = 0;
 		queue_signal->event_mailbox_ptr = knod->mailbox->gaddr +
 			knod->aql_event[idx].slot * 8;
-		/* value is in union with hardware_doorbell_ptr — set last */
+		/* value is in union with hardware_doorbell_ptr - set last */
 		queue_signal->value = 0xffffffffffffffff;
 	}
 	knod_dbg(" pre-create-queue signal=%lld kaddr=%p gaddr=0x%llx\n",
@@ -1363,7 +1363,7 @@ struct knod *knod_alloc_ctx(struct knod_dev *knodev, int queue_cnt, int id,
 			(knod->sdma_event[idx].slot * 8);
 		/* SDMA fence writes u32 to low 32 bits of value.
 		 * Init to 0 (not -1 like AQL) so comparison works.
-		 * value is in union with hardware_doorbell_ptr — set last.
+		 * value is in union with hardware_doorbell_ptr - set last.
 		 */
 		sdma_signal->value = 0;
 		sdma_lptr = knod->mailbox->kaddr + (idx * 8);
@@ -1484,7 +1484,7 @@ void knod_release_ctx(struct knod *knod)
 
 	debugfs_remove_recursive(knod->debug_dir);
 
-	/* Release SDMA queues — destroy queue/event BEFORE freeing BOs.
+	/* Release SDMA queues - destroy queue/event BEFORE freeing BOs.
 	 * Same ordering as knod_destroy_one_queue() for AQL: the queue
 	 * holds references to BO VAs, so freeing BOs first causes the
 	 * queue destroy to fail and leaves internal BOs in kfd_bo_list.
@@ -1512,7 +1512,7 @@ void knod_release_ctx(struct knod *knod)
 
 	/* Tear down the KFD process.  It holds 3 refs:
 	 *   ref 1: "open" ref from kfd_create_process (normally dropped
-	 *           by kfd_release when /dev/kfd is closed — KNOD never
+	 *           by kfd_release when /dev/kfd is closed - KNOD never
 	 *           opens /dev/kfd so we must drop this ourselves)
 	 *   ref 2: KNOD's explicit kref_get in knod_alloc_ctx
 	 *   ref 3: mmu_notifier alloc_notifier ref (dropped by
@@ -1521,11 +1521,11 @@ void knod_release_ctx(struct knod *knod)
 	 * kfd_process_notifier_release_internal removes from hash,
 	 * destroys queues, and calls mmu_notifier_put which schedules
 	 * the SRCU callback to drop ref 3.  We drop refs 1 and 2 here.
-	 * After SRCU fires, ref reaches 0 → kfd_process_wq_release
+	 * After SRCU fires, ref reaches 0 -> kfd_process_wq_release
 	 * runs (sysfs removal, BO/PDD/doorbell/event cleanup, kfree).
 	 *
 	 * kfd_process_destroy_pdds fput's pdd->drm_file (the get_file
-	 * ref from init_vm), bringing the DRM file ref from 2→1.
+	 * ref from init_vm), bringing the DRM file ref from 2->1.
 	 * The file/VM stays alive until we fput the filp_open ref below.
 	 */
 	kfd_process_notifier_release_internal(knod->process);
@@ -1534,7 +1534,7 @@ void knod_release_ctx(struct knod *knod)
 	mmu_notifier_synchronize();
 	kfd_process_flush_wq();
 
-	/* Drop the filp_open ref (file ref 1→0).  kfd_process_destroy_pdds
+	/* Drop the filp_open ref (file ref 1->0).  kfd_process_destroy_pdds
 	 * already fput'd the get_file ref during wq_release above.
 	 */
 	fput(knod->drm_file);
@@ -1619,7 +1619,7 @@ static void knod_feature_deactivate(struct knod *knod)
 	switch (knod->active_feature) {
 	case KNOD_FEATURE_BPF:
 		/*
-		 * Phase 1: unregister the offload dev — this force-frees any
+		 * Phase 1: unregister the offload dev - this force-frees any
 		 * user XDP progs/maps still bound.  The map-free ndo routes
 		 * back through accel_ops.xdp_ops->xdp_install, so xdp_ops must
 		 * still point at the BPF ops (and priv must be alive) here.
@@ -1737,7 +1737,7 @@ static int knod_accel_feature_set(struct knod_accel *accel, u32 feature,
 
 	/*
 	 * Refuse to leave BPF while a user XDP prog or offloaded map is still
-	 * bound — tearing the offload down underneath them is unsafe (the GPU
+	 * bound - tearing the offload down underneath them is unsafe (the GPU
 	 * dispatch keeps running against freed state).  The user must detach
 	 * first, e.g. "ip link set dev <if> xdp off".
 	 */
@@ -1803,15 +1803,15 @@ static int knod_attach(struct knod_dev *knodev)
 	/*
 	 * Keep GFX engine out of GFXOFF while a KNOD accel is attached.
 	 * On RDNA2 (tested RX6600 / gfx1032) the very first AQL dispatch
-	 * after boot hangs with signal=-1 when GFXOFF is active — SMU exit
+	 * after boot hangs with signal=-1 when GFXOFF is active - SMU exit
 	 * from GFXOFF races with the doorbell ring and the completion
 	 * signal is never decremented. Forcing GFXOFF off for the attached
 	 * lifetime avoids the race entirely.
 	 *
 	 * Pin MCLK soft-min to HW max. KNOD's RX path is bandwidth-bound
-	 * on VRAM (NIC→GPU p2pdma delivers frames directly to VRAM, then
+	 * on VRAM (NIC->GPU p2pdma delivers frames directly to VRAM, then
 	 * the shader streams them back out) but the individual dispatches
-	 * are too short for SMU's activity monitor to react — MCLK sticks
+	 * are too short for SMU's activity monitor to react - MCLK sticks
 	 * at the lowest DPM (~96 MHz on RX6600) in AUTO mode and caps
 	 * throughput far below what the compute path can sustain. Switching
 	 * to the COMPUTE power profile did not help on RDNA2: the COMPUTE
@@ -1820,7 +1820,7 @@ static int knod_attach(struct knod_dev *knodev)
 	 *
 	 * Setting soft_min via SetSoftMinByFreq is independent of
 	 * pp_power_profile_mode and of power_dpm_force_performance_level,
-	 * so AUTO governance stays in effect for SCLK/voltage — we get the
+	 * so AUTO governance stays in effect for SCLK/voltage - we get the
 	 * same 30W full-throughput state the user reaches via "force
 	 * performance = manual + echo 3 > pp_dpm_mclk", without the 75W
 	 * voltage pin that PROFILE_PEAK imposes. Passing 0xFFFF MHz lets
@@ -2107,8 +2107,8 @@ EXPORT_SYMBOL(knod_accel_ipsec_unregister);
  * callers raise it but never lower it, so whichever module needs the
  * most queues wins.
  *
- * Must be called before knod_attach() runs — i.e. before any
- * `echo X,0 > /sys/kernel/debug/knod_dev/attach` — otherwise
+ * Must be called before knod_attach() runs - i.e. before any
+ * `echo X,0 > /sys/kernel/debug/knod_dev/attach` - otherwise
  * the already-created knod context keeps its old queue_cnt and the
  * caller must unbind/rebind to pick up the new value.
  *

--- a/drivers/gpu/drm/amd/amdkfd/knod/aesgcm_shader.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/aesgcm_shader.h
@@ -20,8 +20,8 @@
 /* ======================================================================
  * Emit pattern macros (file-local)
  *
- * _E(fn, ...)   — emit instruction, advance n by instruction size
- * _BR(fn, ...)  — emit branch, save position, advance n
+ * _E(fn, ...)   - emit instruction, advance n by instruction size
+ * _BR(fn, ...)  - emit branch, save position, advance n
  * ======================================================================
  */
 
@@ -434,7 +434,7 @@ static int emit_aes_encrypt_block_gfx9(u32 *buf, int n)
 
 	_E(emit_gfx9_s_mov_b32, I9(buf, n), P_S(SR_LOOP_CTR), P_I(0));
 
-	/* Prefetch round 1 key — overlaps with loop-entry overhead */
+	/* Prefetch round 1 key - overlaps with loop-entry overhead */
 	_E(emit_gfx9_s_load_dwordx4, I9(buf, n), P_S(SR_RK), P_S(SR_KEYS), 0);
 
 	loop_top = n;
@@ -830,7 +830,7 @@ static int emit_aes_encrypt_block_gfx10(u32 *buf, int n)
 
 	_E(emit_gfx10_s_mov_b32, I10(buf, n), P_S(SR_LOOP_CTR), P_I(0));
 
-	/* Prefetch round 1 key — overlaps with loop-entry overhead */
+	/* Prefetch round 1 key - overlaps with loop-entry overhead */
 	_E(emit_gfx10_s_load_dwordx4, I10(buf, n), P_S(SR_RK), P_S(SR_KEYS), 0);
 
 	loop_top = n;

--- a/drivers/gpu/drm/amd/amdkfd/knod/ipsec_fused_gfx10.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/ipsec_fused_gfx10.h
@@ -4,30 +4,30 @@
  */
 
 /*
- * KNOD IPsec fused RX shader — GFX9 (Vega10/20).
+ * KNOD IPsec fused RX shader - GFX9 (Vega10/20).
  *
  * Full AES-GCM decrypt pipeline for inbound ESP packets:
- *   1) ESP header parse → SPI + seq extract
- *   2) SA table linear scan → resolve SPI to slot index
- *   3) Cooperative T-table load (VRAM → LDS, 256 threads)
- *   4) AES-CTR decrypt ciphertext → out_addr
+ *   1) ESP header parse -> SPI + seq extract
+ *   2) SA table linear scan -> resolve SPI to slot index
+ *   3) Cooperative T-table load (VRAM -> LDS, 256 threads)
+ *   4) AES-CTR decrypt ciphertext -> out_addr
  *   5) Parallel GHASH over (AAD || ciphertext || len)
- *   6) ICV verify (GHASH ⊕ AES(K,J0) vs received tag)
- *   7) ESP trailer strip → inner_len
+ *   6) ICV verify (GHASH ^ AES(K,J0) vs received tag)
+ *   7) ESP trailer strip -> inner_len
  *   8) Write verdict to bd->act, inner_len to bd->len
  *
  * Dispatch geometry:
- *   workgroup  = (256, 1, 1)     — 256 threads = 1 AES block per thread
+ *   workgroup  = (256, 1, 1)     - 256 threads = 1 AES block per thread
  *   grid       = (256, nr_pkts, 1)
  *   workgroup_id_y == packet index in the batch
  *
- * Anti-replay is NOT in the shader — CPU-side sliding window in NIC NAPI.
+ * Anti-replay is NOT in the shader - CPU-side sliding window in NIC NAPI.
  *
  * Verdict encoding in bd->act high32:
- *   0..NR_SA-1  — SA hit + ICV pass, value is slot_idx
- *   0xFFFFFFFF  — SA miss (no entry for this SPI)
- *   0xFFFFFFFE  — non-IPv4/IPv6 bypass (unknown L3 protocol)
- *   0xFFFFFFFD  — ICV mismatch (decrypt succeeded but tag wrong)
+ *   0..NR_SA-1  - SA hit + ICV pass, value is slot_idx
+ *   0xFFFFFFFF  - SA miss (no entry for this SPI)
+ *   0xFFFFFFFE  - non-IPv4/IPv6 bypass (unknown L3 protocol)
+ *   0xFFFFFFFD  - ICV mismatch (decrypt succeeded but tag wrong)
  *
  * bd->len is set to inner_len on success (decrypted payload minus ESP
  * trailer and padding). On miss/bypass/ICV-fail, bd->len is left as-is.
@@ -47,7 +47,7 @@
 #endif
 #include "aesgcm_shader.h"
 
-/* SA entry constants — must match knod_ipsec.h */
+/* SA entry constants - must match knod_ipsec.h */
 #define KNOD_IPSEC_SHADER_NR_SA	256
 #define KNOD_IPSEC_SHADER_SA_ENTRY_SZ	104
 
@@ -109,7 +109,7 @@
 #define VR_SAVE_STATS_HI	41	/* per-SA stats GPU addr high */
 /* ESP header offset: 34(v4) or 54(v6) */
 #define VR_SAVE_ESP_OFF		42
-/* Ciphertext prefetch destination — free v23-v27, outside AES v0-v22 range */
+/* Ciphertext prefetch destination - free v23-v27, outside AES v0-v22 range */
 #define VR_PREFETCH0		23
 #define VR_PREFETCH1		24
 #define VR_PREFETCH2		25
@@ -136,10 +136,10 @@
 #endif
 
 /*
- * KNOD_IPSEC_GFX10_DIAG_STUB — graduated diagnostic stubs.
+ * KNOD_IPSEC_GFX10_DIAG_STUB - graduated diagnostic stubs.
  * Uncomment exactly one level to bisect the SQC inst-fault:
  *
- *  Level 1: bare s_endpgm — tests KD, entry offset, BO mapping.
+ *  Level 1: bare s_endpgm - tests KD, entry offset, BO mapping.
  *  Level 2: compute bd_addr from kernarg, store 0xDEAD0001, endpgm.
  *           Tests SGPR layout, VOP2/VOP1 ALU, GLOBAL load/store.
  *  Level 3: full Phase 0 (parse + SA scan) + write result, endpgm.
@@ -177,7 +177,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	int n = 0;
 
 #if defined(KNOD_IPSEC_GFX10_DIAG_STUB) && KNOD_IPSEC_GFX10_DIAG_STUB == 1
-	/* LEVEL 1: bare s_endpgm — if this faults, KD or BO mapping is
+	/* LEVEL 1: bare s_endpgm - if this faults, KD or BO mapping is
 	 * wrong
 	 */
 	_E(emit_gfx10_s_endpgm, I10(buf, n));
@@ -273,7 +273,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	_E(emit_gfx10_s_add_u32, I10(buf, n), P_S(28), P_S(28), P_I(1));
 	/* SOP2: s_lshr_b32 s28, s28, 0 (nop shift) */
 	_E(emit_gfx10_s_lshr_b32, I10(buf, n), P_S(28), P_S(28), P_I(0));
-	/* SOPC: s_cmp_eq_u32 s28, 0xCAFE0005 — should set SCC=1 */
+	/* SOPC: s_cmp_eq_u32 s28, 0xCAFE0005 - should set SCC=1 */
 	_E(emit_gfx10_s_cmp_eq_u32, I10(buf, n), P_S(28), P_L(0xCAFE0005u));
 	br_ok = _BR(emit_gfx10_s_cbranch_scc1, I10(buf, n), 0);
 	/* SCC=0 path: write 0xBAD00004 as error marker */
@@ -329,7 +329,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	_E(emit_gfx10_v_add_co_u32, I10(buf, n), P_V(3), P_S(8), P_V(1));
 	_E(emit_gfx10_v_add_co_ci_u32_e32, I10(buf, n), P_V(4), P_I(0), P_V(2));
 
-	/* Load sub[].pkt_addr → v[9:10], sub[].bd_addr → v[5:6] */
+	/* Load sub[].pkt_addr -> v[9:10], sub[].bd_addr -> v[5:6] */
 	_E(emit_gfx10_global_load_dwordx2, I10(buf, n), P_V(9), P_V(3),
 	   SUB_OFF_PKT_ADDR);
 	_E(emit_gfx10_global_load_dwordx2, I10(buf, n), P_V(5), P_V(3),
@@ -350,7 +350,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	_E(emit_gfx10_v_mov_b32_e32, I10(buf, n), P_V(12), P_V(10));
 
 	/* IP version gate: load dword at pkt+12 to get first byte of L3
-	 * header (byte[14]). Extract version nibble → s28.
+	 * header (byte[14]). Extract version nibble -> s28.
 	 */
 	_E(emit_gfx10_global_load_dword, I10(buf, n), P_V(15), P_V(9), 12);
 	_E(emit_gfx10_s_waitcnt_vmcnt, I10(buf, n));
@@ -391,7 +391,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	_E(emit_gfx10_v_add_co_ci_u32_e32, I10(buf, n), P_V(12), P_I(0),
 	   P_V(10));
 
-	/* v13 = *(u32*)(pkt + esp_hdr_off) — SPI in big-endian.
+	/* v13 = *(u32*)(pkt + esp_hdr_off) - SPI in big-endian.
 	 *
 	 * GFX10 (RDNA2) quirk: global_load_dword silently clears EA's
 	 * low 2 bits, so loading at v[11:12] = pkt + 34 (v4) or pkt + 54
@@ -496,20 +496,20 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	_E(emit_gfx10_v_mov_b32_e32, I10(buf, n), P_V(VR_SAVE_PKT_HI), P_V(10));
 	_E(emit_gfx10_v_mov_b32_e32, I10(buf, n), P_V(VR_SAVE_SPI), P_V(13));
 
-	/* Load sub[].out_addr → v[VR_SAVE_OUT_LO:VR_SAVE_OUT_HI] */
+	/* Load sub[].out_addr -> v[VR_SAVE_OUT_LO:VR_SAVE_OUT_HI] */
 	_E(emit_gfx10_global_load_dwordx2, I10(buf, n), P_V(VR_SAVE_OUT_LO),
 	   P_V(3), SUB_OFF_OUT_ADDR);
-	/* Load sub[].pkt_len → v[VR_SAVE_PKTLEN] */
+	/* Load sub[].pkt_len -> v[VR_SAVE_PKTLEN] */
 	_E(emit_gfx10_global_load_dword, I10(buf, n), P_V(VR_SAVE_PKTLEN),
 	   P_V(3), SUB_OFF_PKT_LEN);
 	_E(emit_gfx10_s_waitcnt_vmcnt, I10(buf, n));
 
-	/* Load ESP seq number: pkt + esp_hdr_off + 4, BE → bswap →
+	/* Load ESP seq number: pkt + esp_hdr_off + 4, BE -> bswap ->
 	 * v[VR_SAVE_SEQ].
 	 * v[11:12] still holds pkt_addr + esp_hdr_off from Phase 0.
 	 *
 	 * GFX10 unaligned load fix: esp_hdr_off is 34(v4) or 54(v6),
-	 * both ≡ 2 mod 4. EA = pkt+38 clips to pkt+36. Load dwordx2
+	 * both == 2 mod 4. EA = pkt+38 clips to pkt+36. Load dwordx2
 	 * from the clipped addr, then v_alignbit_b32 shift=16 to
 	 * reconstruct the target dword.  v[20:21] are free scratch.
 	 */
@@ -529,7 +529,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	   P_V(VR_SAVE_SEQ), SUB_OFF_RESULT_SEQ);
 
 	/* ================================================================
-	 * Phase 2: Branch on miss/bypass — skip crypto entirely
+	 * Phase 2: Branch on miss/bypass - skip crypto entirely
 	 * ================================================================
 	 */
 	_E(emit_gfx10_v_readfirstlane_b32, I10(buf, n), 26, VR_SAVE_SLOT);
@@ -558,13 +558,13 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 
 	/* Batched SA entry loads: issue all 4 loads to different
 	 * VGPR destinations, then single waitcnt. v1-v8 (S0-S3,
-	 * D0-D3) are free at Phase 3 — not used until Phase 7.
+	 * D0-D3) are free at Phase 3 - not used until Phase 7.
 	 *
 	 * Layout:
-	 *   dwordx4 @+16 → v[1:4]: key_lo, key_hi, htable_lo, htable_hi
-	 *   dwordx4 @+32 → v[5:8]: ttables_lo, ttables_hi, salt, key_len
-	 *   dwordx2 @+48 → v[14:15]: nr_rounds, mode
-	 *   dwordx2 @+88 → v[16:17]: stats_lo, stats_hi
+	 *   dwordx4 @+16 -> v[1:4]: key_lo, key_hi, htable_lo, htable_hi
+	 *   dwordx4 @+32 -> v[5:8]: ttables_lo, ttables_hi, salt, key_len
+	 *   dwordx2 @+48 -> v[14:15]: nr_rounds, mode
+	 *   dwordx2 @+88 -> v[16:17]: stats_lo, stats_hi
 	 */
 	_E(emit_gfx10_global_load_dwordx4, I10(buf, n), P_V(VR_S0),
 	   P_V(VR_GA_LO), SA_OFF_KEY_ADDR);
@@ -590,7 +590,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	/* nr_rounds: v14, mode: v15 */
 	_E(emit_gfx10_v_readfirstlane_b32, I10(buf, n), SR_NR_ROUNDS, VR_DATA0);
 	_E(emit_gfx10_v_readfirstlane_b32, I10(buf, n), SR_SA_MODE, VR_DATA1);
-	/* stats_addr: v16=lo, v17=hi → save VGPRs for Phase 10 */
+	/* stats_addr: v16=lo, v17=hi -> save VGPRs for Phase 10 */
 	_E(emit_gfx10_v_mov_b32_e32, I10(buf, n), P_V(VR_SAVE_STATS_LO),
 	   P_V(VR_DATA2));
 	_E(emit_gfx10_v_mov_b32_e32, I10(buf, n), P_V(VR_SAVE_STATS_HI),
@@ -610,7 +610,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	   P_V(VR_SAVE_ESP_OFF), P_V(VR_SAVE_PKT_LO));
 	_E(emit_gfx10_v_add_co_ci_u32_e32, I10(buf, n), P_V(VR_GA_HI),
 	   P_I(0), P_V(VR_SAVE_PKT_HI));
-	/* GFX10 unaligned load fix: EA = pkt+42/62 ≡ 2 mod 4, clips
+	/* GFX10 unaligned load fix: EA = pkt+42/62 == 2 mod 4, clips
 	 * to pkt+40/60. Load dwordx4 (16B from clipped addr), then
 	 * alignbit shift=16 to reconstruct IV[0:3] and IV[4:7].
 	 */
@@ -631,7 +631,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	 * ctext_len = pkt_len - ctext_off - ICV_LEN
 	 * nblocks = (ctext_len + 15) >> 4
 	 *
-	 * s28 is free here (last used in version gate) — use as scratch.
+	 * s28 is free here (last used in version gate) - use as scratch.
 	 * ================================================================
 	 */
 	_E(emit_gfx10_v_readfirstlane_b32, I10(buf, n), 28, VR_SAVE_ESP_OFF);
@@ -653,10 +653,10 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	   P_I(2), P_S(SR_NBLOCKS_GCM));
 
 	/* ================================================================
-	 * Phase 6: Cooperative T-table load (VRAM → LDS)
+	 * Phase 6: Cooperative T-table load (VRAM -> LDS)
 	 *
 	 * All 256 threads load from SA's t_tables_gpu_addr. Each thread
-	 * loads one u32 per table (4 tables × 256 entries = 4KB).
+	 * loads one u32 per table (4 tables x 256 entries = 4KB).
 	 * ================================================================
 	 */
 	_E(emit_gfx10_s_mov_b32, I10(buf, n), P_S(SR_MASK), P_L(0xFF));
@@ -665,7 +665,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	_E(emit_gfx10_v_lshlrev_b32, I10(buf, n), P_V(VR_TMP), P_I(2),
 	   P_V(VR_TID));
 
-	/* T0: VRAM[t_tables + tid*4] → LDS[tid*4] */
+	/* T0: VRAM[t_tables + tid*4] -> LDS[tid*4] */
 	_E(emit_gfx10_v_mov_b32_e32, I10(buf, n), P_V(VR_GA_LO),
 	   P_S(SR_T_ADDR));
 	_E(emit_gfx10_v_mov_b32_e32, I10(buf, n), P_V(VR_GA_HI),
@@ -708,7 +708,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	_E(emit_gfx10_s_barrier, I10(buf, n));
 
 #if defined(KNOD_IPSEC_GFX10_DIAG_STUB) && KNOD_IPSEC_GFX10_DIAG_STUB == 6
-	/* LEVEL 6: early exit after Phase 6 (T-table → LDS + barrier).
+	/* LEVEL 6: early exit after Phase 6 (T-table -> LDS + barrier).
 	 * Tests Phase 1-6: SA loads, nonce build, DS writes, s_barrier.
 	 * bd_addr is in v[VR_SAVE_BD_LO:VR_SAVE_BD_HI] = v[31:32].
 	 */
@@ -733,11 +733,11 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	 *
 	 * Each thread handles block_id = tid. Only threads with tid <
 	 * nblocks are active. Counter = nonce[12] || bswap32(tid+2).
-	 * AES-encrypt the counter → keystream. XOR with ciphertext →
+	 * AES-encrypt the counter -> keystream. XOR with ciphertext ->
 	 * plaintext. Store to out_addr + tid*16.
 	 * ================================================================
 	 */
-	/* VCC = (nblocks > tid) i.e. tid < nblocks — selects active CTR lanes
+	/* VCC = (nblocks > tid) i.e. tid < nblocks - selects active CTR lanes
 	 */
 	_E(emit_gfx10_v_cmp_gt_u32, I10(buf, n), P_S(SR_NBLOCKS_GCM),
 	   P_V(VR_TID));
@@ -751,7 +751,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	   P_S(SR_KEYS + 1));
 
 	/* Prefetch ciphertext into v[23:27] before AES.
-	 * GFX10 unaligned fix: ctext addr ≡ 2 mod 4, so load
+	 * GFX10 unaligned fix: ctext addr == 2 mod 4, so load
 	 * dwordx4 (clips to aligned) + extra dword at +16.
 	 * The ~200+ cycle AES encrypt hides the VMEM latency.
 	 * v23-v27 are not touched by AES rounds (which use
@@ -792,7 +792,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	_E(emit_gfx10_v_perm_b32, I10(buf, n), P_V(VR_S3), P_V(VR_S3),
 	   P_V(VR_S3), P_S(SR_BSWAP));
 
-	/* AES encrypt the counter block → result in v[VR_S0:VR_S3] */
+	/* AES encrypt the counter block -> result in v[VR_S0:VR_S3] */
 #if defined(KNOD_IPSEC_GFX10_DIAG_STUB) && KNOD_IPSEC_GFX10_DIAG_STUB == 7
 	/* LEVEL 7: exit just before emit_aes_encrypt_block_gfx10.
 	 * If this passes but Level 8 (after encrypt) faults,
@@ -835,10 +835,10 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	return n * 4;
 #endif
 
-	/* Ciphertext arrived during AES — drain vmcnt */
+	/* Ciphertext arrived during AES - drain vmcnt */
 	_E(emit_gfx10_s_waitcnt_vmcnt, I10(buf, n));
 
-	/* GFX10 unaligned fix: 4× alignbit on prefetched data */
+	/* GFX10 unaligned fix: 4x alignbit on prefetched data */
 	_E(emit_gfx10_v_alignbit_b32, I10(buf, n), P_V(VR_PREFETCH0),
 	   P_V(VR_PREFETCH1), P_V(VR_PREFETCH0), P_I(16));
 	_E(emit_gfx10_v_alignbit_b32, I10(buf, n), P_V(VR_PREFETCH1),
@@ -848,7 +848,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	_E(emit_gfx10_v_alignbit_b32, I10(buf, n), P_V(VR_PREFETCH3),
 	   P_V(VR_PREFETCH4), P_V(VR_PREFETCH3), P_I(16));
 
-	/* XOR keystream with ciphertext → plaintext */
+	/* XOR keystream with ciphertext -> plaintext */
 	_E(emit_gfx10_v_xor_b32_e32, I10(buf, n), P_V(VR_PREFETCH0),
 	   P_V(VR_S0), P_V(VR_PREFETCH0));
 	_E(emit_gfx10_v_xor_b32_e32, I10(buf, n), P_V(VR_PREFETCH1),
@@ -892,7 +892,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 
 	n = emit_aes_encrypt_block_gfx10(buf, n);
 
-	/* Save AES(K, J0) → v[VR_J0_0:VR_J0_3] */
+	/* Save AES(K, J0) -> v[VR_J0_0:VR_J0_3] */
 	_E(emit_gfx10_v_mov_b32_e32, I10(buf, n), P_V(VR_J0_0), P_V(VR_S0));
 	_E(emit_gfx10_v_mov_b32_e32, I10(buf, n), P_V(VR_J0_1), P_V(VR_S1));
 	_E(emit_gfx10_v_mov_b32_e32, I10(buf, n), P_V(VR_J0_2), P_V(VR_S2));
@@ -925,14 +925,14 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	 * Phase 8: Parallel GHASH
 	 *
 	 * GHASH input blocks (total_blocks = nblocks + 2):
-	 *   tid 0            → AAD: SPI(4B,BE)||seq(4B,BE)||0s (16B)
-	 *   tid 1..nblocks   → ciphertext block (tid-1)
-	 *   tid nblocks+1    → len: AAD_bitlen(64b)||ctext_bitlen(64b)
-	 *   tid > nblocks+1  → zero (does not participate)
+	 *   tid 0            -> AAD: SPI(4B,BE)||seq(4B,BE)||0s (16B)
+	 *   tid 1..nblocks   -> ciphertext block (tid-1)
+	 *   tid nblocks+1    -> len: AAD_bitlen(64b)||ctext_bitlen(64b)
+	 *   tid > nblocks+1  -> zero (does not participate)
 	 *
-	 * Each thread loads its block → v[VR_DATA0:VR_DATA3] (big-endian
-	 * for GF multiply), loads H^(total-tid) → v[VR_D0:VR_D3], runs
-	 * GF multiply → v[VR_S0:VR_S3], then tree-reduces via LDS XOR.
+	 * Each thread loads its block -> v[VR_DATA0:VR_DATA3] (big-endian
+	 * for GF multiply), loads H^(total-tid) -> v[VR_D0:VR_D3], runs
+	 * GF multiply -> v[VR_S0:VR_S3], then tree-reduces via LDS XOR.
 	 * ================================================================
 	 */
 	/* Prefetch H^(total-tid) from H-power table before data selection.
@@ -978,7 +978,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 
 	/* VR_SAVE_SPI/SEQ are already in BE register convention:
 	 * raw LE load from packet (BE wire bytes) + bswap = byte[0]
-	 * in bits[31:24]. No second bswap needed — use directly.
+	 * in bits[31:24]. No second bswap needed - use directly.
 	 */
 	_E(emit_gfx10_v_mov_b32_e32, I10(buf, n), P_V(VR_DATA0),
 	   P_V(VR_SAVE_SPI));
@@ -1004,7 +1004,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	return n * 4;
 #endif
 	/* ---- Ctext: 1 <= tid <= nblocks ---- */
-	/* block_idx = tid - 1 (unsigned; tid==0 → 0xFFFFFFFF > nblocks) */
+	/* block_idx = tid - 1 (unsigned; tid==0 -> 0xFFFFFFFF > nblocks) */
 	_E(emit_gfx10_v_add_nc_u32, I10(buf, n), P_V(VR_TMP), P_L(0xFFFFFFFF),
 	   P_V(VR_TID));
 	_E(emit_gfx10_v_cmp_gt_u32, I10(buf, n), P_S(SR_NBLOCKS_GCM),
@@ -1043,8 +1043,8 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	   P_V(VR_GA_LO), P_V(VR_TMP));
 	_E(emit_gfx10_v_add_co_ci_u32_e32, I10(buf, n), P_V(VR_GA_HI),
 	   P_I(0), P_V(VR_GA_HI));
-	/* GFX10 unaligned load fix: ctext addr ≡ 2 mod 4.
-	 * dwordx4 + extra dword + 4× alignbit. VR_BLK is free.
+	/* GFX10 unaligned load fix: ctext addr == 2 mod 4.
+	 * dwordx4 + extra dword + 4x alignbit. VR_BLK is free.
 	 */
 	_E(emit_gfx10_global_load_dwordx4, I10(buf, n), P_V(VR_DATA0),
 	   P_V(VR_GA_LO), 0);
@@ -1077,14 +1077,14 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 #endif
 	/* Zero trailing dwords in the last partial ctext block.
 	 * The load above reads 16 raw bytes, but for the last block
-	 * only (ctext_len % 16) bytes are ciphertext — the rest are
+	 * only (ctext_len % 16) bytes are ciphertext - the rest are
 	 * ICV bytes which must NOT enter GHASH.  ESP ctext is always
-	 * 4-byte aligned so the partial count is 4, 8 or 12 — pure
+	 * 4-byte aligned so the partial count is 4, 8 or 12 - pure
 	 * dword-level zeroing suffices, no byte masking needed.
 	 *
 	 * VR_TMP still holds block_idx * 16 from the address calc.
 	 * remaining = ctext_len - block_idx*16. For full blocks
-	 * (remaining >= 16) every v_cmp evaluates true → no change.
+	 * (remaining >= 16) every v_cmp evaluates true -> no change.
 	 */
 	_E(emit_gfx10_v_sub_nc_u32, I10(buf, n), P_V(VR_TMP),
 	   P_S(SR_CTEXT_LEN), P_V(VR_TMP));
@@ -1176,7 +1176,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 
 	/* Length block format (GCM big-endian):
 	 *   DATA0 = AAD_bits[63:32] = 0
-	 *   DATA1 = AAD_bits[31:0]  = 64  (8 bytes AAD × 8)
+	 *   DATA1 = AAD_bits[31:0]  = 64  (8 bytes AAD x 8)
 	 *   DATA2 = ctext_bits[63:32] = 0
 	 *   DATA3 = ctext_bits[31:0] = ctext_len * 8
 	 *
@@ -1325,8 +1325,8 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	   P_V(VR_S3), P_V(VR_J0_3));
 
 	/* Load received ICV: pkt + pkt_len - 16.
-	 * GFX10 unaligned load fix: ICV addr ≡ 2 mod 4.
-	 * dwordx4 + extra dword + 4× alignbit. VR_TMP is
+	 * GFX10 unaligned load fix: ICV addr == 2 mod 4.
+	 * dwordx4 + extra dword + 4x alignbit. VR_TMP is
 	 * free after address calc; use VR_BLK for 5th dword.
 	 */
 	_E(emit_gfx10_v_add_nc_u32, I10(buf, n), P_V(VR_TMP),
@@ -1349,7 +1349,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	_E(emit_gfx10_v_alignbit_b32, I10(buf, n), P_V(VR_DATA3),
 	   P_V(VR_BLK), P_V(VR_DATA3), P_I(16));
 
-	/* Compare: XOR each dword, OR together; if any non-zero → fail */
+	/* Compare: XOR each dword, OR together; if any non-zero -> fail */
 	_E(emit_gfx10_v_xor_b32_e32, I10(buf, n), P_V(VR_DATA0),
 	   P_V(VR_DATA0), P_V(VR_S0));
 	_E(emit_gfx10_v_xor_b32_e32, I10(buf, n), P_V(VR_DATA1),
@@ -1365,7 +1365,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	_E(emit_gfx10_v_or_b32_e32, I10(buf, n), P_V(VR_DATA0),
 	   P_V(VR_DATA0), P_V(VR_DATA3));
 
-	/* If VR_DATA0 != 0 → ICV fail: overwrite verdict with sentinel */
+	/* If VR_DATA0 != 0 -> ICV fail: overwrite verdict with sentinel */
 	_E(emit_gfx10_v_cmp_ne_u32, I10(buf, n), P_I(0), P_V(VR_DATA0));
 	br_icv_ok = _BR(emit_gfx10_s_cbranch_vccz, I10(buf, n), 0);
 	_E(emit_gfx10_v_mov_b32_e32, I10(buf, n), P_V(VR_SAVE_SLOT),
@@ -1483,7 +1483,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	 * pkt + 14 (skip ETH) to out_addr - 20. In shader-GTT
 	 * direct mode (knod_ipsec_sdma=0), out_addr - 20 is
 	 * pass_buf_slot + 0 so the host-side finalise can skip
-	 * the per-packet L3 SDMA copy entirely — the only
+	 * the per-packet L3 SDMA copy entirely - the only
 	 * remaining SDMA call on the transport IPv4 fast path.
 	 *
 	 * Tunnel-mode SAs (SR_SA_MODE != 0) skip this write
@@ -1498,9 +1498,9 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	 * so the shader's write is harmless wasted work.
 	 *
 	 * Alignment: pkt + 14 is only 2-byte aligned (ETH hdr
-	 * = 14 bytes ≠ 4-byte multiple), so dword / dwordx4
-	 * loads would fault. Use 10 × global_load_ushort at
-	 * offsets 14,16,...,32, paired with 10 × store_short
+	 * = 14 bytes != 4-byte multiple), so dword / dwordx4
+	 * loads would fault. Use 10 x global_load_ushort at
+	 * offsets 14,16,...,32, paired with 10 x store_short
 	 * at slot + 0,2,...,18. 10 scratch VGPRs (v14..v23),
 	 * all free by Phase 10 since AES-GCM / GHASH state is
 	 * done. One waitcnt between loads and stores.
@@ -1520,7 +1520,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	   P_V(VR_GA_HI), P_I(0),
 	   P_V(VR_SAVE_PKT_HI));
 
-	/* 10 × 2-byte loads from src+0..+18 */
+	/* 10 x 2-byte loads from src+0..+18 */
 	for (li = 0; li < 10; li++) {
 		_E(emit_gfx10_global_load_ushort,
 		   I10(buf, n),
@@ -1535,7 +1535,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	 *
 	 *  1. v_add_co_u32 can't take a 32-bit
 	 *     literal src together with implicit VCC
-	 *     — same class as the v_cndmask literal
+	 *     - same class as the v_cndmask literal
 	 *     restriction.
 	 *  2. P_I(n) is a raw initializer that always
 	 *     sets type=INTEGER_0 and stores n in .v.
@@ -1564,7 +1564,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	   P_V(VR_GA_HI),
 	   P_V(VR_TMP2), P_V(VR_SAVE_OUT_HI));
 
-	/* 10 × 2-byte stores to dst+0..+18 */
+	/* 10 x 2-byte stores to dst+0..+18 */
 	for (li = 0; li < 10; li++) {
 		_E(emit_gfx10_global_store_short,
 		   I10(buf, n),
@@ -1598,7 +1598,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	patch_branch(buf, br_tid0, n);
 
 	/* ================================================================
-	 * Phase 11: Miss/bypass path verdict — thread 0 only
+	 * Phase 11: Miss/bypass path verdict - thread 0 only
 	 *
 	 * If we skipped crypto (Phase 2 branch), write the miss/bypass
 	 * sentinel that's still in v[VR_SAVE_SLOT].
@@ -1642,7 +1642,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	 *  - v_add_nc_u32 / v_sub_nc_u32 (no-carry variants)
 	 *  - v_add_co_ci_u32_e32 for carry-in addition
 	 *  - s_or_b64 for 64-bit zero test (no s_or_b32 helper)
-	 *  - GFX10 global offset is 12-bit signed (all offsets ≤56 OK)
+	 *  - GFX10 global offset is 12-bit signed (all offsets <=56 OK)
 	 * ================================================================
 	 */
 	/* --- kernarg loads ---------------------------------------- */
@@ -1661,7 +1661,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	_E(emit_gfx10_v_mov_b32_e32, I10(buf, n), P_V(2), P_S(27));
 
 	/* ctl+28: wptr_base_dw(4) ring_mask(4) nr_total_wg(4) copy_hdr(4)
-	 * → v[3:6]
+	 * -> v[3:6]
 	 */
 	_E(emit_gfx10_global_load_dwordx4, I10(buf, n),
 	   P_V(3), P_V(1), 28);
@@ -1681,7 +1681,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 
 	/* === This WG needs SDMA copy === */
 
-	/* atomic_add(&ctl->claim_counter, 1, GLC=1) → my_idx */
+	/* atomic_add(&ctl->claim_counter, 1, GLC=1) -> my_idx */
 	_E(emit_gfx10_v_mov_b32_e32, I10(buf, n), P_V(7), P_I(1));
 	_E(emit_gfx10_global_atomic_add, I10(buf, n),
 	   P_V(7), P_V(1), P_V(7), 0, 1);
@@ -1698,7 +1698,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	_E(emit_gfx10_v_and_b32_e32, I10(buf, n),
 	   P_V(8), P_V(4), P_V(8));		/* & ring_mask */
 	_E(emit_gfx10_v_lshlrev_b32, I10(buf, n),
-	   P_V(8), P_I(2), P_V(8));		/* * 4 → byte offset */
+	   P_V(8), P_I(2), P_V(8));		/* * 4 -> byte offset */
 
 	/* v[9:10] = sdma_ring_addr + byte_offset */
 	_E(emit_gfx10_v_mov_b32_e32, I10(buf, n), P_V(14), P_S(25));
@@ -1728,7 +1728,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	_E(emit_gfx10_global_store_dword, I10(buf, n),
 	   P_V(9), P_V(VR_SAVE_PKT_HI), 16);
 
-	/* DW5-6: dst = out_addr − 20 (GTT slot start) */
+	/* DW5-6: dst = out_addr - 20 (GTT slot start) */
 	_E(emit_gfx10_v_mov_b32_e32, I10(buf, n),
 	   P_V(14), P_L(0xFFFFFFECu));		/* -20 */
 	_E(emit_gfx10_v_add_co_u32, I10(buf, n),
@@ -1760,7 +1760,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	_E(emit_gfx10_s_cmp_eq_u32, I10(buf, n), P_S(29), P_S(28));
 	br_not_last = _BR(emit_gfx10_s_cbranch_scc0, I10(buf, n), 0);
 
-	/* === Last WG — publish counters for CPU === */
+	/* === Last WG - publish counters for CPU === */
 
 	/* Read final claim_counter (atomic add 0, GLC=1) */
 	_E(emit_gfx10_v_mov_b32_e32, I10(buf, n), P_V(7), P_I(0));
@@ -1784,7 +1784,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	/* GFX10 RDNA2 prefetches instructions aggressively past s_endpgm.
 	 * Without an s_code_end cushion the SQC fetches garbage beyond the
 	 * shader and raises an SQC(inst) page fault at a seemingly random
-	 * address. Pad to a 256-dword boundary — same pattern the BPF GFX10
+	 * address. Pad to a 256-dword boundary - same pattern the BPF GFX10
 	 * emitter (knod_bpf.c) uses on working shaders.
 	 */
 	while (n % 256)

--- a/drivers/gpu/drm/amd/amdkfd/knod/ipsec_fused_gfx9.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/ipsec_fused_gfx9.h
@@ -4,30 +4,30 @@
  */
 
 /*
- * KNOD IPsec fused RX shader — GFX9 (Vega10/20).
+ * KNOD IPsec fused RX shader - GFX9 (Vega10/20).
  *
  * Full AES-GCM decrypt pipeline for inbound ESP packets:
- *   1) ESP header parse → SPI + seq extract
- *   2) SA table linear scan → resolve SPI to slot index
- *   3) Cooperative T-table load (VRAM → LDS, 256 threads)
- *   4) AES-CTR decrypt ciphertext → out_addr
+ *   1) ESP header parse -> SPI + seq extract
+ *   2) SA table linear scan -> resolve SPI to slot index
+ *   3) Cooperative T-table load (VRAM -> LDS, 256 threads)
+ *   4) AES-CTR decrypt ciphertext -> out_addr
  *   5) Parallel GHASH over (AAD || ciphertext || len)
- *   6) ICV verify (GHASH ⊕ AES(K,J0) vs received tag)
- *   7) ESP trailer strip → inner_len
+ *   6) ICV verify (GHASH ^ AES(K,J0) vs received tag)
+ *   7) ESP trailer strip -> inner_len
  *   8) Write verdict to bd->act, inner_len to bd->len
  *
  * Dispatch geometry:
- *   workgroup  = (256, 1, 1)     — 256 threads = 1 AES block per thread
+ *   workgroup  = (256, 1, 1)     - 256 threads = 1 AES block per thread
  *   grid       = (256, nr_pkts, 1)
  *   workgroup_id_y == packet index in the batch
  *
- * Anti-replay is NOT in the shader — CPU-side sliding window in NIC NAPI.
+ * Anti-replay is NOT in the shader - CPU-side sliding window in NIC NAPI.
  *
  * Verdict encoding in bd->act high32:
- *   0..NR_SA-1  — SA hit + ICV pass, value is slot_idx
- *   0xFFFFFFFF  — SA miss (no entry for this SPI)
- *   0xFFFFFFFE  — non-IPv4/IPv6 bypass (unknown L3 protocol)
- *   0xFFFFFFFD  — ICV mismatch (decrypt succeeded but tag wrong)
+ *   0..NR_SA-1  - SA hit + ICV pass, value is slot_idx
+ *   0xFFFFFFFF  - SA miss (no entry for this SPI)
+ *   0xFFFFFFFE  - non-IPv4/IPv6 bypass (unknown L3 protocol)
+ *   0xFFFFFFFD  - ICV mismatch (decrypt succeeded but tag wrong)
  *
  * bd->len is set to inner_len on success (decrypted payload minus ESP
  * trailer and padding). On miss/bypass/ICV-fail, bd->len is left as-is.
@@ -47,7 +47,7 @@
 #endif
 #include "aesgcm_shader.h"
 
-/* SA entry constants — must match knod_ipsec.h */
+/* SA entry constants - must match knod_ipsec.h */
 #define KNOD_IPSEC_SHADER_NR_SA	256
 #define KNOD_IPSEC_SHADER_SA_ENTRY_SZ	104
 
@@ -109,7 +109,7 @@
 #define VR_SAVE_STATS_HI	41	/* per-SA stats GPU addr high */
 /* ESP header offset: 34(v4) or 54(v6) */
 #define VR_SAVE_ESP_OFF		42
-/* Ciphertext prefetch destination — free v23-v26, inside AES v0-v22 gap */
+/* Ciphertext prefetch destination - free v23-v26, inside AES v0-v22 gap */
 #define VR_PREFETCH0		23
 #define VR_PREFETCH1		24
 #define VR_PREFETCH2		25
@@ -174,7 +174,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	_E(emit_gfx9_v_add_co_u32, I9(buf, n), P_V(3), P_S(8), P_V(1));
 	_E(emit_gfx9_v_addc_co_u32, I9(buf, n), P_V(4), P_I(0), P_V(2));
 
-	/* Load sub[].pkt_addr → v[9:10], sub[].bd_addr → v[5:6] */
+	/* Load sub[].pkt_addr -> v[9:10], sub[].bd_addr -> v[5:6] */
 	_E(emit_gfx9_global_load_dwordx2, I9(buf, n), P_V(9), P_V(3),
 	   SUB_OFF_PKT_ADDR);
 	_E(emit_gfx9_global_load_dwordx2, I9(buf, n), P_V(5), P_V(3),
@@ -195,7 +195,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	_E(emit_gfx9_v_mov_b32_e32, I9(buf, n), P_V(12), P_V(10));
 
 	/* IP version gate: load dword at pkt+12 to get first byte of L3
-	 * header (byte[14]). Extract version nibble → s28.
+	 * header (byte[14]). Extract version nibble -> s28.
 	 */
 	_E(emit_gfx9_global_load_dword, I9(buf, n), P_V(15), P_V(9), 12);
 	_E(emit_gfx9_s_waitcnt_vmcnt, I9(buf, n));
@@ -235,7 +235,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	   P_V(VR_SAVE_ESP_OFF), P_V(9));
 	_E(emit_gfx9_v_addc_co_u32, I9(buf, n), P_V(12), P_I(0), P_V(10));
 
-	/* v13 = *(u32*)(pkt + esp_hdr_off) — SPI in big-endian */
+	/* v13 = *(u32*)(pkt + esp_hdr_off) - SPI in big-endian */
 	_E(emit_gfx9_global_load_dword, I9(buf, n), P_V(13), P_V(11), 0);
 	_E(emit_gfx9_s_waitcnt_vmcnt, I9(buf, n));
 
@@ -305,15 +305,15 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	_E(emit_gfx9_v_mov_b32_e32, I9(buf, n), P_V(VR_SAVE_PKT_HI), P_V(10));
 	_E(emit_gfx9_v_mov_b32_e32, I9(buf, n), P_V(VR_SAVE_SPI), P_V(13));
 
-	/* Load sub[].out_addr → v[VR_SAVE_OUT_LO:VR_SAVE_OUT_HI] */
+	/* Load sub[].out_addr -> v[VR_SAVE_OUT_LO:VR_SAVE_OUT_HI] */
 	_E(emit_gfx9_global_load_dwordx2, I9(buf, n), P_V(VR_SAVE_OUT_LO),
 	   P_V(3), SUB_OFF_OUT_ADDR);
-	/* Load sub[].pkt_len → v[VR_SAVE_PKTLEN] */
+	/* Load sub[].pkt_len -> v[VR_SAVE_PKTLEN] */
 	_E(emit_gfx9_global_load_dword, I9(buf, n), P_V(VR_SAVE_PKTLEN),
 	   P_V(3), SUB_OFF_PKT_LEN);
 	_E(emit_gfx9_s_waitcnt_vmcnt, I9(buf, n));
 
-	/* Load ESP seq number: pkt + esp_hdr_off + 4, BE → bswap →
+	/* Load ESP seq number: pkt + esp_hdr_off + 4, BE -> bswap ->
 	 * v[VR_SAVE_SEQ].
 	 * v[11:12] still holds pkt_addr + esp_hdr_off from Phase 0.
 	 */
@@ -331,7 +331,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	   P_V(VR_SAVE_SEQ), SUB_OFF_RESULT_SEQ);
 
 	/* ================================================================
-	 * Phase 2: Branch on miss/bypass — skip crypto entirely
+	 * Phase 2: Branch on miss/bypass - skip crypto entirely
 	 * ================================================================
 	 */
 	_E(emit_gfx9_v_readfirstlane_b32, I9(buf, n), 26, VR_SAVE_SLOT);
@@ -360,13 +360,13 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 
 	/* Batched SA entry loads: issue all 4 loads to different
 	 * VGPR destinations, then single waitcnt. v1-v8 (S0-S3,
-	 * D0-D3) are free at Phase 3 — not used until Phase 7.
+	 * D0-D3) are free at Phase 3 - not used until Phase 7.
 	 *
 	 * Layout:
-	 *   dwordx4 @+16 → v[1:4]: key_lo, key_hi, htable_lo, htable_hi
-	 *   dwordx4 @+32 → v[5:8]: ttables_lo, ttables_hi, salt, key_len
-	 *   dwordx2 @+48 → v[14:15]: nr_rounds, mode
-	 *   dwordx2 @+88 → v[16:17]: stats_lo, stats_hi
+	 *   dwordx4 @+16 -> v[1:4]: key_lo, key_hi, htable_lo, htable_hi
+	 *   dwordx4 @+32 -> v[5:8]: ttables_lo, ttables_hi, salt, key_len
+	 *   dwordx2 @+48 -> v[14:15]: nr_rounds, mode
+	 *   dwordx2 @+88 -> v[16:17]: stats_lo, stats_hi
 	 */
 	_E(emit_gfx9_global_load_dwordx4, I9(buf, n), P_V(VR_S0),
 	   P_V(VR_GA_LO), SA_OFF_KEY_ADDR);
@@ -392,7 +392,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	/* nr_rounds: v14, mode: v15 */
 	_E(emit_gfx9_v_readfirstlane_b32, I9(buf, n), SR_NR_ROUNDS, VR_DATA0);
 	_E(emit_gfx9_v_readfirstlane_b32, I9(buf, n), SR_SA_MODE, VR_DATA1);
-	/* stats_addr: v16=lo, v17=hi → save VGPRs for Phase 10 */
+	/* stats_addr: v16=lo, v17=hi -> save VGPRs for Phase 10 */
 	_E(emit_gfx9_v_mov_b32_e32, I9(buf, n), P_V(VR_SAVE_STATS_LO),
 	   P_V(VR_DATA2));
 	_E(emit_gfx9_v_mov_b32_e32, I9(buf, n), P_V(VR_SAVE_STATS_HI),
@@ -425,7 +425,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	 * ctext_len = pkt_len - ctext_off - ICV_LEN
 	 * nblocks = (ctext_len + 15) >> 4
 	 *
-	 * s28 is free here (last used in version gate) — use as scratch.
+	 * s28 is free here (last used in version gate) - use as scratch.
 	 * ================================================================
 	 */
 	_E(emit_gfx9_v_readfirstlane_b32, I9(buf, n), 28, VR_SAVE_ESP_OFF);
@@ -447,10 +447,10 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	   P_I(2), P_S(SR_NBLOCKS_GCM));
 
 	/* ================================================================
-	 * Phase 6: Cooperative T-table load (VRAM → LDS)
+	 * Phase 6: Cooperative T-table load (VRAM -> LDS)
 	 *
 	 * All 256 threads load from SA's t_tables_gpu_addr. Each thread
-	 * loads one u32 per table (4 tables × 256 entries = 4KB).
+	 * loads one u32 per table (4 tables x 256 entries = 4KB).
 	 * ================================================================
 	 */
 	_E(emit_gfx9_s_mov_b32, I9(buf, n), P_S(SR_MASK), P_L(0xFF));
@@ -459,7 +459,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	_E(emit_gfx9_v_lshlrev_b32, I9(buf, n), P_V(VR_TMP), P_I(2),
 	   P_V(VR_TID));
 
-	/* T0: VRAM[t_tables + tid*4] → LDS[tid*4] */
+	/* T0: VRAM[t_tables + tid*4] -> LDS[tid*4] */
 	_E(emit_gfx9_v_mov_b32_e32, I9(buf, n), P_V(VR_GA_LO), P_S(SR_T_ADDR));
 	_E(emit_gfx9_v_mov_b32_e32, I9(buf, n), P_V(VR_GA_HI),
 	   P_S(SR_T_ADDR + 1));
@@ -497,11 +497,11 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	 *
 	 * Each thread handles block_id = tid. Only threads with tid <
 	 * nblocks are active. Counter = nonce[12] || bswap32(tid+2).
-	 * AES-encrypt the counter → keystream. XOR with ciphertext →
+	 * AES-encrypt the counter -> keystream. XOR with ciphertext ->
 	 * plaintext. Store to out_addr + tid*16.
 	 * ================================================================
 	 */
-	/* VCC = (nblocks > tid) i.e. tid < nblocks — selects active CTR lanes
+	/* VCC = (nblocks > tid) i.e. tid < nblocks - selects active CTR lanes
 	 */
 	_E(emit_gfx9_v_cmp_gt_u32, I9(buf, n), P_S(SR_NBLOCKS_GCM),
 	   P_V(VR_TID));
@@ -551,13 +551,13 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	_E(emit_gfx9_v_perm_b32, I9(buf, n), P_V(VR_S3), P_V(VR_S3),
 	   P_V(VR_S3), P_S(SR_BSWAP));
 
-	/* AES encrypt the counter block → result in v[VR_S0:VR_S3] */
+	/* AES encrypt the counter block -> result in v[VR_S0:VR_S3] */
 	n = emit_aes_encrypt_block_gfx9(buf, n);
 
-	/* Ciphertext arrived during AES — drain vmcnt */
+	/* Ciphertext arrived during AES - drain vmcnt */
 	_E(emit_gfx9_s_waitcnt_vmcnt, I9(buf, n));
 
-	/* XOR keystream with prefetched ciphertext → plaintext */
+	/* XOR keystream with prefetched ciphertext -> plaintext */
 	_E(emit_gfx9_v_xor_b32_e32, I9(buf, n), P_V(VR_PREFETCH0),
 	   P_V(VR_S0), P_V(VR_PREFETCH0));
 	_E(emit_gfx9_v_xor_b32_e32, I9(buf, n), P_V(VR_PREFETCH1),
@@ -601,7 +601,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 
 	n = emit_aes_encrypt_block_gfx9(buf, n);
 
-	/* Save AES(K, J0) → v[VR_J0_0:VR_J0_3] */
+	/* Save AES(K, J0) -> v[VR_J0_0:VR_J0_3] */
 	_E(emit_gfx9_v_mov_b32_e32, I9(buf, n), P_V(VR_J0_0), P_V(VR_S0));
 	_E(emit_gfx9_v_mov_b32_e32, I9(buf, n), P_V(VR_J0_1), P_V(VR_S1));
 	_E(emit_gfx9_v_mov_b32_e32, I9(buf, n), P_V(VR_J0_2), P_V(VR_S2));
@@ -613,14 +613,14 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	 * Phase 8: Parallel GHASH
 	 *
 	 * GHASH input blocks (total_blocks = nblocks + 2):
-	 *   tid 0            → AAD: SPI(4B,BE)||seq(4B,BE)||0s (16B)
-	 *   tid 1..nblocks   → ciphertext block (tid-1)
-	 *   tid nblocks+1    → len: AAD_bitlen(64b)||ctext_bitlen(64b)
-	 *   tid > nblocks+1  → zero (does not participate)
+	 *   tid 0            -> AAD: SPI(4B,BE)||seq(4B,BE)||0s (16B)
+	 *   tid 1..nblocks   -> ciphertext block (tid-1)
+	 *   tid nblocks+1    -> len: AAD_bitlen(64b)||ctext_bitlen(64b)
+	 *   tid > nblocks+1  -> zero (does not participate)
 	 *
-	 * Each thread loads its block → v[VR_DATA0:VR_DATA3] (big-endian
-	 * for GF multiply), loads H^(total-tid) → v[VR_D0:VR_D3], runs
-	 * GF multiply → v[VR_S0:VR_S3], then tree-reduces via LDS XOR.
+	 * Each thread loads its block -> v[VR_DATA0:VR_DATA3] (big-endian
+	 * for GF multiply), loads H^(total-tid) -> v[VR_D0:VR_D3], runs
+	 * GF multiply -> v[VR_S0:VR_S3], then tree-reduces via LDS XOR.
 	 * ================================================================
 	 */
 	/* Prefetch H^(total-tid) from H-power table before data selection.
@@ -666,7 +666,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 
 	/* VR_SAVE_SPI/SEQ are already in BE register convention:
 	 * raw LE load from packet (BE wire bytes) + bswap = byte[0]
-	 * in bits[31:24]. No second bswap needed — use directly.
+	 * in bits[31:24]. No second bswap needed - use directly.
 	 */
 	_E(emit_gfx9_v_mov_b32_e32, I9(buf, n), P_V(VR_DATA0),
 	   P_V(VR_SAVE_SPI));
@@ -679,7 +679,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	   SR_GHASH_EXEC);
 
 	/* ---- Ctext: 1 <= tid <= nblocks ---- */
-	/* block_idx = tid - 1 (unsigned; tid==0 → 0xFFFFFFFF > nblocks) */
+	/* block_idx = tid - 1 (unsigned; tid==0 -> 0xFFFFFFFF > nblocks) */
 	_E(emit_gfx9_v_add_u32, I9(buf, n), P_V(VR_TMP), P_L(0xFFFFFFFF),
 	   P_V(VR_TID));
 	_E(emit_gfx9_v_cmp_gt_u32, I9(buf, n), P_S(SR_NBLOCKS_GCM),
@@ -709,14 +709,14 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 
 	/* Zero trailing dwords in the last partial ctext block.
 	 * The load above reads 16 raw bytes, but for the last block
-	 * only (ctext_len % 16) bytes are ciphertext — the rest are
+	 * only (ctext_len % 16) bytes are ciphertext - the rest are
 	 * ICV bytes which must NOT enter GHASH.  ESP ctext is always
-	 * 4-byte aligned so the partial count is 4, 8 or 12 — pure
+	 * 4-byte aligned so the partial count is 4, 8 or 12 - pure
 	 * dword-level zeroing suffices, no byte masking needed.
 	 *
 	 * VR_TMP still holds block_idx * 16 from the address calc.
 	 * remaining = ctext_len - block_idx*16. For full blocks
-	 * (remaining >= 16) every v_cmp evaluates true → no change.
+	 * (remaining >= 16) every v_cmp evaluates true -> no change.
 	 */
 	_E(emit_gfx9_v_sub_u32, I9(buf, n), P_V(VR_TMP),
 	   P_S(SR_CTEXT_LEN), P_V(VR_TMP));
@@ -765,7 +765,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 
 	/* Length block format (GCM big-endian):
 	 *   DATA0 = AAD_bits[63:32] = 0
-	 *   DATA1 = AAD_bits[31:0]  = 64  (8 bytes AAD × 8)
+	 *   DATA1 = AAD_bits[31:0]  = 64  (8 bytes AAD x 8)
 	 *   DATA2 = ctext_bits[63:32] = 0
 	 *   DATA3 = ctext_bits[31:0] = ctext_len * 8
 	 *
@@ -900,7 +900,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	   P_V(VR_GA_LO), 0);
 	_E(emit_gfx9_s_waitcnt_vmcnt, I9(buf, n));
 
-	/* Compare: XOR each dword, OR together; if any non-zero → fail */
+	/* Compare: XOR each dword, OR together; if any non-zero -> fail */
 	_E(emit_gfx9_v_xor_b32_e32, I9(buf, n), P_V(VR_DATA0),
 	   P_V(VR_DATA0), P_V(VR_S0));
 	_E(emit_gfx9_v_xor_b32_e32, I9(buf, n), P_V(VR_DATA1),
@@ -916,7 +916,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	_E(emit_gfx9_v_or_b32_e32, I9(buf, n), P_V(VR_DATA0),
 	   P_V(VR_DATA0), P_V(VR_DATA3));
 
-	/* If VR_DATA0 != 0 → ICV fail: overwrite verdict with sentinel */
+	/* If VR_DATA0 != 0 -> ICV fail: overwrite verdict with sentinel */
 	_E(emit_gfx9_v_cmp_ne_u32, I9(buf, n), P_I(0), P_V(VR_DATA0));
 	br_icv_ok = _BR(emit_gfx9_s_cbranch_vccz, I9(buf, n), 0);
 	_E(emit_gfx9_v_mov_b32_e32, I9(buf, n), P_V(VR_SAVE_SLOT),
@@ -1034,7 +1034,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	 * pkt + 14 (skip ETH) to out_addr - 20. In shader-GTT
 	 * direct mode (knod_ipsec_sdma=0), out_addr - 20 is
 	 * pass_buf_slot + 0 so the host-side finalise can skip
-	 * the per-packet L3 SDMA copy entirely — the only
+	 * the per-packet L3 SDMA copy entirely - the only
 	 * remaining SDMA call on the transport IPv4 fast path.
 	 *
 	 * Tunnel-mode SAs (SR_SA_MODE != 0) skip this write
@@ -1049,9 +1049,9 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	 * so the shader's write is harmless wasted work.
 	 *
 	 * Alignment: pkt + 14 is only 2-byte aligned (ETH hdr
-	 * = 14 bytes ≠ 4-byte multiple), so dword / dwordx4
-	 * loads would fault. Use 10 × global_load_ushort at
-	 * offsets 14,16,...,32, paired with 10 × store_short
+	 * = 14 bytes != 4-byte multiple), so dword / dwordx4
+	 * loads would fault. Use 10 x global_load_ushort at
+	 * offsets 14,16,...,32, paired with 10 x store_short
 	 * at slot + 0,2,...,18. 10 scratch VGPRs (v14..v23),
 	 * all free by Phase 10 since AES-GCM / GHASH state is
 	 * done. One waitcnt between loads and stores.
@@ -1070,7 +1070,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	   P_V(VR_GA_HI), P_I(0),
 	   P_V(VR_SAVE_PKT_HI));
 
-	/* 10 × 2-byte loads from src+0..+18 */
+	/* 10 x 2-byte loads from src+0..+18 */
 	for (li = 0; li < 10; li++) {
 		_E(emit_gfx9_global_load_ushort,
 		   I9(buf, n),
@@ -1085,7 +1085,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	 *
 	 *  1. v_add_co_u32 can't take a 32-bit
 	 *     literal src together with implicit VCC
-	 *     — same class as the v_cndmask literal
+	 *     - same class as the v_cndmask literal
 	 *     restriction.
 	 *  2. P_I(n) is a raw initializer that always
 	 *     sets type=INTEGER_0 and stores n in .v.
@@ -1114,7 +1114,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	   P_V(VR_GA_HI),
 	   P_V(VR_TMP2), P_V(VR_SAVE_OUT_HI));
 
-	/* 10 × 2-byte stores to dst+0..+18 */
+	/* 10 x 2-byte stores to dst+0..+18 */
 	for (li = 0; li < 10; li++) {
 		_E(emit_gfx9_global_store_short,
 		   I9(buf, n),
@@ -1148,7 +1148,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	patch_branch(buf, br_tid0, n);
 
 	/* ================================================================
-	 * Phase 11: Miss/bypass path verdict — thread 0 only
+	 * Phase 11: Miss/bypass path verdict - thread 0 only
 	 *
 	 * If we skipped crypto (Phase 2 branch), write the miss/bypass
 	 * sentinel that's still in v[VR_SAVE_SLOT].
@@ -1189,14 +1189,14 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	 * vector memory ops are NOPs when EXEC=0.
 	 *
 	 * The GPU writes SDMA COPY_LINEAR packets only.  FENCE, wptr
-	 * update, and doorbell are left to the CPU — this avoids a race
+	 * update, and doorbell are left to the CPU - this avoids a race
 	 * where a GPU-emitted FENCE would prematurely satisfy the CPU
 	 * fence poll before CPU-added SDMA copies (e.g. IPv6 transport
 	 * L3 header) complete.
 	 *
 	 * Protocol per work-group (= per packet):
 	 *  1. Load sdma_ring_addr (kernarg+16) and sdma_ctl_addr (+32).
-	 *  2. If sdma_ctl_addr == 0, gpu_sdma disabled — skip.
+	 *  2. If sdma_ctl_addr == 0, gpu_sdma disabled - skip.
 	 *  3. Load sdma_ctl fields (wptr_base_dw, ring_mask, etc.).
 	 *  4. If verdict is MISS/BYPASS, claim a ring slot via
 	 *     atomic_add(&claim_counter) and write a 7-dword
@@ -1223,7 +1223,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	_E(emit_gfx9_v_mov_b32_e32, I9(buf, n), P_V(2), P_S(27));
 
 	/* ctl+28: wptr_base_dw(4) ring_mask(4) nr_total_wg(4) copy_hdr(4)
-	 * → v[3:6]
+	 * -> v[3:6]
 	 */
 	_E(emit_gfx9_global_load_dwordx4, I9(buf, n),
 	   P_V(3), P_V(1), 28);
@@ -1243,7 +1243,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 
 	/* === This WG needs SDMA copy === */
 
-	/* atomic_add(&ctl->claim_counter, 1, GLC=1) → my_idx */
+	/* atomic_add(&ctl->claim_counter, 1, GLC=1) -> my_idx */
 	_E(emit_gfx9_v_mov_b32_e32, I9(buf, n), P_V(7), P_I(1));
 	_E(emit_gfx9_global_atomic_add, I9(buf, n),
 	   P_V(7), P_V(1), P_V(7), 0, 1);
@@ -1260,7 +1260,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	_E(emit_gfx9_v_and_b32_e32, I9(buf, n),
 	   P_V(8), P_V(4), P_V(8));		/* & ring_mask */
 	_E(emit_gfx9_v_lshlrev_b32, I9(buf, n),
-	   P_V(8), P_I(2), P_V(8));		/* * 4 → byte offset */
+	   P_V(8), P_I(2), P_V(8));		/* * 4 -> byte offset */
 
 	/* v[9:10] = sdma_ring_addr + byte_offset */
 	_E(emit_gfx9_v_mov_b32_e32, I9(buf, n), P_V(14), P_S(25));
@@ -1290,7 +1290,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	_E(emit_gfx9_global_store_dword, I9(buf, n),
 	   P_V(9), P_V(VR_SAVE_PKT_HI), 16);
 
-	/* DW5-6: dst = out_addr − 20 (GTT slot start) */
+	/* DW5-6: dst = out_addr - 20 (GTT slot start) */
 	_E(emit_gfx9_v_mov_b32_e32, I9(buf, n),
 	   P_V(14), P_L(0xFFFFFFECu));		/* -20 */
 	_E(emit_gfx9_v_add_co_u32, I9(buf, n),
@@ -1322,7 +1322,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx9(void *vbuf)
 	_E(emit_gfx9_s_cmp_eq_u32, I9(buf, n), P_S(29), P_S(28));
 	br_not_last = _BR(emit_gfx9_s_cbranch_scc0, I9(buf, n), 0);
 
-	/* === Last WG — publish counters for CPU === */
+	/* === Last WG - publish counters for CPU === */
 
 	/* Read final claim_counter (atomic add 0, GLC=1) */
 	_E(emit_gfx9_v_mov_b32_e32, I9(buf, n), P_V(7), P_I(0));

--- a/drivers/gpu/drm/amd/amdkfd/knod/kfd_knod.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/kfd_knod.h
@@ -147,7 +147,7 @@ struct knod {
 	struct kfd_event_data *event_data;
 	struct knod_accel *accel;
 	struct dentry *debug_dir;
-	/* Worker callback — one active worker at a time */
+	/* Worker callback - one active worker at a time */
 	enum knod_feature active_feature;
 	knod_worker_fn_t worker_fn;
 	knod_flush_fn_t flush_fn;

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_amdgpu.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_amdgpu.h
@@ -115,7 +115,7 @@ inline void knod_iset64(struct amdgcn_param64 *param,
 
 	if (imm1 > 64 || imm1 < -16) {
 		param->hi.type = AMDGCN_PARAM_TYPE_LITERAL_CONST;
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 		param->hi.v = imm1;
 	} else if (imm1 >= 0) {
 		param->hi.type = AMDGCN_PARAM_TYPE_INTEGER_0;

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_amdgpu.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_amdgpu.h
@@ -144,7 +144,7 @@ inline bool knod_param_is_literal(struct amdgcn_param32 param)
 }
 
 /* ======================================================================
- * Param constructors — common to GFX9/GFX10 shader emitters.
+ * Param constructors - common to GFX9/GFX10 shader emitters.
  *
  * Usage: pass directly to emit_gfx{9,10}_* functions that take
  *        struct amdgcn_param32 operands.
@@ -159,7 +159,7 @@ inline bool knod_param_is_literal(struct amdgcn_param32 param)
 #define P_EXEC	((struct amdgcn_param32){ AMDGCN_PARAM_TYPE_EXEC_LO, 0 })
 
 /* ======================================================================
- * Branch patching — operates directly on u32 *buf
+ * Branch patching - operates directly on u32 *buf
  * ======================================================================
  */
 

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_amdgpu_insn.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_amdgpu_insn.h
@@ -1914,7 +1914,7 @@ static inline void emit_s_load_dwordx2(int version, struct amdgcn_insn *insn,
 						      offset);
 		insn->type = AMDGCN_INSN_TYPE_SMEM;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -1936,7 +1936,7 @@ static inline void emit_s_load_dwordx2_soff(int version,
 		insn->gfx9.smem.soffset = soffset;
 		insn->type = AMDGCN_INSN_TYPE_SMEM;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -1954,7 +1954,7 @@ static inline void emit_s_lshl_b32(int version, struct amdgcn_insn *insn,
 						   src0, src1);
 		insn->type = AMDGCN_INSN_TYPE_SOP2;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -1976,7 +1976,7 @@ static inline void emit_v_bfe_i32(int version, struct amdgcn_insn *insn,
 						 dst, src0, src1, src2);
 		insn->type = AMDGCN_INSN_TYPE_VOP3A;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -1998,7 +1998,7 @@ static inline void emit_v_bfe_u32(int version, struct amdgcn_insn *insn,
 						 dst, src0, src1, src2);
 		insn->type = AMDGCN_INSN_TYPE_VOP3A;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2020,7 +2020,7 @@ static inline void emit_v_bfi_b32(int version, struct amdgcn_insn *insn,
 						 dst, src0, src1, src2);
 		insn->type = AMDGCN_INSN_TYPE_VOP3A;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2039,7 +2039,7 @@ static inline void emit_v_lshl_add_u32(int version, struct amdgcn_insn *insn,
 						      dst, src0, src1, src2);
 		insn->type = AMDGCN_INSN_TYPE_VOP3A;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2058,7 +2058,7 @@ static inline void emit_v_lshl_or_b32(int version, struct amdgcn_insn *insn,
 						     dst, src0, src1, src2);
 		insn->type = AMDGCN_INSN_TYPE_VOP3A;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2079,7 +2079,7 @@ static inline void emit_v_alignbit_b32(int version, struct amdgcn_insn *insn,
 						      src1, src2);
 		insn->type = AMDGCN_INSN_TYPE_VOP3A;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2101,7 +2101,7 @@ static inline void emit_v_perm_b32(int version, struct amdgcn_insn *insn,
 						   dst, src0, src1, src2);
 		insn->type = AMDGCN_INSN_TYPE_VOP3A;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2123,7 +2123,7 @@ static inline void emit_v_mad_u64_u32(int version, struct amdgcn_insn *insn,
 						     src1, src2);
 		insn->type = AMDGCN_INSN_TYPE_VOP3B;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2137,7 +2137,7 @@ static inline void emit_s_mov_b32(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_s_mov_b32(&insn->gfx9, dst, src);
 		insn->type = AMDGCN_INSN_TYPE_SOP1;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2152,7 +2152,7 @@ static inline void emit_v_mov_b32_e32(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_v_mov_b32_e32(&insn->gfx9, dst, src);
 		insn->type = AMDGCN_INSN_TYPE_VOP1;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2169,7 +2169,7 @@ static inline void emit_v_readfirstlane_b32(int version,
 							   sdst, vsrc);
 		insn->type = AMDGCN_INSN_TYPE_VOP1;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2188,7 +2188,7 @@ static inline void emit_v_add_co_u32(int version, struct amdgcn_insn *insn,
 						    src0, src1);
 		insn->type = AMDGCN_INSN_TYPE_VOP2;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2208,7 +2208,7 @@ static inline void emit_v_add_co_ci_u32_e32(int version,
 						     src0, src1);
 		insn->type = AMDGCN_INSN_TYPE_VOP2;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2229,7 +2229,7 @@ static inline void emit_v_add_u32(int version, struct amdgcn_insn *insn,
 						    src0, src1);
 		insn->type = AMDGCN_INSN_TYPE_VOP2;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2250,7 +2250,7 @@ static inline void emit_v_sub_u32(int version, struct amdgcn_insn *insn,
 						    src0, src1);
 		insn->type = AMDGCN_INSN_TYPE_VOP2;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2270,7 +2270,7 @@ static inline void emit_v_xor_b32_e32(int version, struct amdgcn_insn *insn,
 						     src0, src1);
 		insn->type = AMDGCN_INSN_TYPE_VOP2;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2290,7 +2290,7 @@ static inline void emit_v_or_b32_e32(int version, struct amdgcn_insn *insn,
 						     src0, src1);
 		insn->type = AMDGCN_INSN_TYPE_VOP2;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2310,7 +2310,7 @@ static inline void emit_v_cndmask_b32_e32(int version, struct amdgcn_insn *insn,
 							  src0, src1);
 		insn->type = AMDGCN_INSN_TYPE_VOP2;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2330,7 +2330,7 @@ static inline void emit_v_and_b32_e32(int version, struct amdgcn_insn *insn,
 						     src0, src1);
 		insn->type = AMDGCN_INSN_TYPE_VOP2;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2351,7 +2351,7 @@ static inline void emit_v_sub_co_ci_u32_e32(int version,
 						     src0, src1);
 		insn->type = AMDGCN_INSN_TYPE_VOP2;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2372,7 +2372,7 @@ static inline void emit_v_subrev_co_ci_u32_e32(int version,
 							src0, src1);
 		insn->type = AMDGCN_INSN_TYPE_VOP2;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2391,7 +2391,7 @@ static inline void emit_v_sub_co_u32(int version, struct amdgcn_insn *insn,
 						    src0, src1);
 		insn->type = AMDGCN_INSN_TYPE_VOP2;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2410,7 +2410,7 @@ static inline void emit_v_subrev_co_u32(int version, struct amdgcn_insn *insn,
 						       src0, src1);
 		insn->type = AMDGCN_INSN_TYPE_VOP2;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2428,7 +2428,7 @@ static inline void emit_v_mul_lo_u32(int version, struct amdgcn_insn *insn,
 						    src0, src1);
 		insn->type = AMDGCN_INSN_TYPE_VOP3A;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2447,7 +2447,7 @@ static inline void emit_v_mbcnt_lo_u32_b32(int version,
 							   dst, src0, src1);
 		insn->type = AMDGCN_INSN_TYPE_VOP3A;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2466,7 +2466,7 @@ static inline void emit_v_mbcnt_hi_u32_b32(int version,
 							   dst, src0, src1);
 		insn->type = AMDGCN_INSN_TYPE_VOP3A;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2484,7 +2484,7 @@ static inline void emit_v_mul_hi_u32(int version, struct amdgcn_insn *insn,
 						    src0, src1);
 		insn->type = AMDGCN_INSN_TYPE_VOP3A;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2503,7 +2503,7 @@ static inline void emit_v_lshlrev_b64(int version, struct amdgcn_insn *insn,
 						     src0, src1);
 		insn->type = AMDGCN_INSN_TYPE_VOP3A;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2522,7 +2522,7 @@ static inline void emit_v_lshrrev_b64(int version, struct amdgcn_insn *insn,
 						     src0, src1);
 		insn->type = AMDGCN_INSN_TYPE_VOP3A;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2540,7 +2540,7 @@ static inline void emit_v_ashrrev_i64(int version, struct amdgcn_insn *insn,
 						     src1);
 		insn->type = AMDGCN_INSN_TYPE_VOP3A;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2558,7 +2558,7 @@ static inline void emit_v_ashrrev_i32(int version, struct amdgcn_insn *insn,
 						     src1);
 		insn->type = AMDGCN_INSN_TYPE_VOP3A;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2578,7 +2578,7 @@ static inline void emit_v_lshlrev_b32(int version, struct amdgcn_insn *insn,
 						     src0, src1);
 		insn->type = AMDGCN_INSN_TYPE_VOP2;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2598,7 +2598,7 @@ static inline void emit_v_lshrrev_b32(int version, struct amdgcn_insn *insn,
 						     src0, src1);
 		insn->type = AMDGCN_INSN_TYPE_VOP2;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2615,7 +2615,7 @@ static inline void emit_v_cmp_eq_u64(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_v_cmp_eq_u64(&insn->gfx9, dst, src);
 		insn->type = AMDGCN_INSN_TYPE_VOPC;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2632,7 +2632,7 @@ static inline void emit_v_cmp_eq_u32(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_v_cmp_eq_u32(&insn->gfx9, dst, src);
 		insn->type = AMDGCN_INSN_TYPE_VOPC;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2648,7 +2648,7 @@ static inline void emit_v_cmp_gt_u64(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_v_cmp_gt_u64(&insn->gfx9, dst, src);
 		insn->type = AMDGCN_INSN_TYPE_VOPC;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2664,7 +2664,7 @@ static inline void emit_v_cmp_gt_i64(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_v_cmp_gt_i64(&insn->gfx9, dst, src);
 		insn->type = AMDGCN_INSN_TYPE_VOPC;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2680,7 +2680,7 @@ static inline void emit_v_cmp_ge_u32(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_v_cmp_ge_u32(&insn->gfx9, dst, src);
 		insn->type = AMDGCN_INSN_TYPE_VOPC;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2697,7 +2697,7 @@ static inline void emit_v_cmp_gt_u32(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_v_cmp_gt_u32(&insn->gfx9, dst, src);
 		insn->type = AMDGCN_INSN_TYPE_VOPC;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2714,7 +2714,7 @@ static inline void emit_v_cmp_lt_u32(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_v_cmp_lt_u32(&insn->gfx9, dst, src);
 		insn->type = AMDGCN_INSN_TYPE_VOPC;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2731,7 +2731,7 @@ static inline void emit_v_cmp_le_u32(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_v_cmp_le_u32(&insn->gfx9, dst, src);
 		insn->type = AMDGCN_INSN_TYPE_VOPC;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2748,7 +2748,7 @@ static inline void emit_v_cmp_gt_i32(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_v_cmp_gt_i32(&insn->gfx9, dst, src);
 		insn->type = AMDGCN_INSN_TYPE_VOPC;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2765,7 +2765,7 @@ static inline void emit_v_cmp_ge_i32(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_v_cmp_ge_i32(&insn->gfx9, dst, src);
 		insn->type = AMDGCN_INSN_TYPE_VOPC;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2782,7 +2782,7 @@ static inline void emit_v_cmp_lt_i32(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_v_cmp_lt_i32(&insn->gfx9, dst, src);
 		insn->type = AMDGCN_INSN_TYPE_VOPC;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2799,7 +2799,7 @@ static inline void emit_v_cmp_le_i32(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_v_cmp_le_i32(&insn->gfx9, dst, src);
 		insn->type = AMDGCN_INSN_TYPE_VOPC;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2816,7 +2816,7 @@ static inline void emit_v_cmpx_lt_u32(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_v_cmpx_lt_u32(&insn->gfx9, dst, src);
 		insn->type = AMDGCN_INSN_TYPE_VOPC;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2832,7 +2832,7 @@ static inline void emit_v_cmp_ge_u64(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_v_cmp_ge_u64(&insn->gfx9, dst, src);
 		insn->type = AMDGCN_INSN_TYPE_VOPC;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2848,7 +2848,7 @@ static inline void emit_v_cmp_ge_i64(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_v_cmp_ge_i64(&insn->gfx9, dst, src);
 		insn->type = AMDGCN_INSN_TYPE_VOPC;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2864,7 +2864,7 @@ static inline void emit_v_cmp_lt_u64(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_v_cmp_lt_u64(&insn->gfx9, dst, src);
 		insn->type = AMDGCN_INSN_TYPE_VOPC;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2880,7 +2880,7 @@ static inline void emit_v_cmp_lt_i64(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_v_cmp_lt_i64(&insn->gfx9, dst, src);
 		insn->type = AMDGCN_INSN_TYPE_VOPC;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2896,7 +2896,7 @@ static inline void emit_v_cmp_le_u64(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_v_cmp_le_u64(&insn->gfx9, dst, src);
 		insn->type = AMDGCN_INSN_TYPE_VOPC;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2912,7 +2912,7 @@ static inline void emit_v_cmp_le_i64(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_v_cmp_le_i64(&insn->gfx9, dst, src);
 		insn->type = AMDGCN_INSN_TYPE_VOPC;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2930,7 +2930,7 @@ static inline void emit_buffer_load_ubyte(int version, struct amdgcn_insn *insn,
 							  dst, src, off);
 		insn->type = AMDGCN_INSN_TYPE_MUBUF;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2949,7 +2949,7 @@ static inline void emit_buffer_load_ushort(int version,
 							  dst, src, off);
 		insn->type = AMDGCN_INSN_TYPE_MUBUF;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2967,7 +2967,7 @@ static inline void emit_buffer_load_dword(int version, struct amdgcn_insn *insn,
 							 dst, src, off);
 		insn->type = AMDGCN_INSN_TYPE_MUBUF;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -2986,7 +2986,7 @@ static inline void emit_buffer_load_dwordx2(int version,
 							   dst, src, off);
 		insn->type = AMDGCN_INSN_TYPE_MUBUF;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3005,7 +3005,7 @@ static inline void emit_buffer_load_dwordx4(int version,
 							   dst, src, off);
 		insn->type = AMDGCN_INSN_TYPE_MUBUF;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3023,7 +3023,7 @@ static inline void emit_global_load_ubyte(int version, struct amdgcn_insn *insn,
 							 dst, src, off);
 		insn->type = AMDGCN_INSN_TYPE_FLAT;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3042,7 +3042,7 @@ static inline void emit_global_load_ushort(int version,
 							  dst, src, off);
 		insn->type = AMDGCN_INSN_TYPE_FLAT;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3062,7 +3062,7 @@ static inline void emit_global_load_dword(int version, struct amdgcn_insn *insn,
 							 dst, src, off);
 		insn->type = AMDGCN_INSN_TYPE_FLAT;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3081,7 +3081,7 @@ static inline void emit_global_load_dwordx2(int version,
 							   dst, src, off);
 		insn->type = AMDGCN_INSN_TYPE_FLAT;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3100,7 +3100,7 @@ static inline void emit_global_load_dwordx4(int version,
 							   dst, src, off);
 		insn->type = AMDGCN_INSN_TYPE_FLAT;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3117,7 +3117,7 @@ static inline void emit_global_store_byte(int version, struct amdgcn_insn *insn,
 							 src, dst, off);
 		insn->type = AMDGCN_INSN_TYPE_FLAT;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3138,7 +3138,7 @@ static inline void emit_global_atomic_##name(int version,		\
 			&insn->gfx9, vdst, addr, data, off, glc);	\
 		insn->type = AMDGCN_INSN_TYPE_FLAT;			\
 	} else {							\
-		WARN_ON(1);						\
+		WARN_ON_ONCE(1);						\
 	}								\
 }
 
@@ -3169,7 +3169,7 @@ static inline void emit_global_store_short(int version,
 							  src, dst, off);
 		insn->type = AMDGCN_INSN_TYPE_FLAT;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3187,7 +3187,7 @@ static inline void emit_global_store_dword(int version,
 							  src, dst, off);
 		insn->type = AMDGCN_INSN_TYPE_FLAT;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3205,7 +3205,7 @@ static inline void emit_global_store_dwordx2(int version,
 							    src, dst, off);
 		insn->type = AMDGCN_INSN_TYPE_FLAT;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3223,7 +3223,7 @@ static inline void emit_global_store_dwordx4(int version,
 							    src, dst, off);
 		insn->type = AMDGCN_INSN_TYPE_FLAT;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3237,7 +3237,7 @@ static inline void emit_s_branch(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_s_branch(&insn->gfx9, off);
 		insn->type = AMDGCN_INSN_TYPE_SOPP;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3251,7 +3251,7 @@ static inline void emit_s_cbranch_vccz(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_s_cbranch_vccz(&insn->gfx9, off);
 		insn->type = AMDGCN_INSN_TYPE_SOPP;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3265,7 +3265,7 @@ static inline void emit_s_cbranch_vccnz(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_s_cbranch_vccnz(&insn->gfx9, off);
 		insn->type = AMDGCN_INSN_TYPE_SOPP;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3286,7 +3286,7 @@ static inline void emit_s_and_saveexec_b64(int version,
 							   sdst, ssrc);
 		insn->type = AMDGCN_INSN_TYPE_SOP1;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3302,7 +3302,7 @@ static inline void emit_s_bcnt1_i32_b64(int version, struct amdgcn_insn *insn,
 							sdst, ssrc);
 		insn->type = AMDGCN_INSN_TYPE_SOP1;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3316,7 +3316,7 @@ static inline void emit_s_mov_b64(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_s_mov_b64(&insn->gfx9, sdst, ssrc);
 		insn->type = AMDGCN_INSN_TYPE_SOP1;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3332,7 +3332,7 @@ static inline void emit_s_and_b64(int version, struct amdgcn_insn *insn,
 						  sdst, ssrc0, ssrc1);
 		insn->type = AMDGCN_INSN_TYPE_SOP2;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3348,7 +3348,7 @@ static inline void emit_s_or_b64(int version, struct amdgcn_insn *insn,
 						 sdst, ssrc0, ssrc1);
 		insn->type = AMDGCN_INSN_TYPE_SOP2;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3364,7 +3364,7 @@ static inline void emit_s_andn2_b64(int version, struct amdgcn_insn *insn,
 						    sdst, ssrc0, ssrc1);
 		insn->type = AMDGCN_INSN_TYPE_SOP2;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3378,7 +3378,7 @@ static inline void emit_s_cbranch_execz(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_s_cbranch_execz(&insn->gfx9, off);
 		insn->type = AMDGCN_INSN_TYPE_SOPP;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3392,7 +3392,7 @@ static inline void emit_s_cbranch_execnz(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_s_cbranch_execnz(&insn->gfx9, off);
 		insn->type = AMDGCN_INSN_TYPE_SOPP;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3408,7 +3408,7 @@ static inline void emit_s_sub_u32(int version, struct amdgcn_insn *insn,
 						  sdst, ssrc0, ssrc1);
 		insn->type = AMDGCN_INSN_TYPE_SOP2;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3422,7 +3422,7 @@ static inline void emit_s_cbranch_scc0(int version, struct amdgcn_insn *insn,
 		insn->size = emit_gfx9_s_cbranch_scc0(&insn->gfx9, off);
 		insn->type = AMDGCN_INSN_TYPE_SOPP;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3434,7 +3434,7 @@ static inline void emit_branch_fixup(int version, struct amdgcn_insn *insn,
 	else if (version == 9)
 		insn->size = emit_gfx9_branch_fixup(&insn->gfx9, off);
 	else
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 }
 
 static inline void emit_s_waitcnt_lgkmcnt(int version, struct amdgcn_insn *insn)
@@ -3446,7 +3446,7 @@ static inline void emit_s_waitcnt_lgkmcnt(int version, struct amdgcn_insn *insn)
 		insn->size = emit_gfx9_s_waitcnt_lgkmcnt(&insn->gfx9);
 		insn->type = AMDGCN_INSN_TYPE_SOPP;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3459,7 +3459,7 @@ static inline void emit_s_waitcnt_vmcnt(int version, struct amdgcn_insn *insn)
 		insn->size = emit_gfx9_s_waitcnt_vmcnt(&insn->gfx9);
 		insn->type = AMDGCN_INSN_TYPE_SOPP;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3473,7 +3473,7 @@ static inline void emit_s_waitcnt_vmcnt_lgkmcnt(int version,
 		insn->size = emit_gfx9_s_waitcnt_vmcnt_lgkmcnt(&insn->gfx9);
 		insn->type = AMDGCN_INSN_TYPE_SOPP;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3486,7 +3486,7 @@ static inline void emit_s_nop(int version, struct amdgcn_insn *insn)
 		insn->size = emit_gfx9_s_nop(&insn->gfx9);
 		insn->type = AMDGCN_INSN_TYPE_SOPP;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3499,7 +3499,7 @@ static inline void emit_s_endpgm(int version, struct amdgcn_insn *insn)
 		insn->size = emit_gfx9_s_endpgm(&insn->gfx9);
 		insn->type = AMDGCN_INSN_TYPE_SOPP;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3509,9 +3509,9 @@ static inline void emit_s_code_end(int version, struct amdgcn_insn *insn)
 		insn->size = emit_gfx10_s_code_end(&insn->gfx10);
 		insn->type = AMDGCN_INSN_TYPE_SOPP;
 	} else if (version == 9) {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -3524,7 +3524,7 @@ static inline void emit_s_icache_inv(int version, struct amdgcn_insn *insn)
 		insn->size = emit_gfx9_s_icache_inv(&insn->gfx9);
 		insn->type = AMDGCN_INSN_TYPE_SOPP;
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -4202,7 +4202,7 @@ static inline void gfx10_debug_insn(struct amdgcn_insn *insn)
 		gfx10_debug_exp(&insn->gfx10);
 		break;
 	default:
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 		break;
 	}
 
@@ -4216,7 +4216,7 @@ static inline void gfx10_debug_insn(struct amdgcn_insn *insn)
 		pr_debug("knod_asm %s %u %.8X %.8X %.8X\n",
 			 __func__, __LINE__, ptr[0], ptr[1], ptr[2]);
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -4854,7 +4854,7 @@ static inline void gfx9_debug_insn(struct amdgcn_insn *insn)
 		gfx9_debug_exp(&insn->gfx9);
 		break;
 	default:
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 		break;
 	}
 
@@ -4868,7 +4868,7 @@ static inline void gfx9_debug_insn(struct amdgcn_insn *insn)
 		pr_debug("knod_asm %s %u %.8X %.8X %.8X\n",
 			 __func__, __LINE__, ptr[0], ptr[1], ptr[2]);
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -4879,7 +4879,7 @@ static inline void debug_insn(int version, struct amdgcn_insn *insn)
 	else if (version == 9)
 		gfx9_debug_insn(insn);
 	else
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 }
 
 static inline void gfx10_debugfs_vop3a(union amdgcn_gfx10_insn *insn,
@@ -5478,7 +5478,7 @@ static inline void gfx10_debugfs_insn(struct amdgcn_insn *insn,
 	else if (insn->size == 12)
 		seq_printf(m, "%.8X %.8X %.8X\t\t\t", ptr[0], ptr[1], ptr[2]);
 	else
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 
 	switch (insn->type) {
 	case AMDGCN_INSN_TYPE_SOP2:
@@ -5551,7 +5551,7 @@ static inline void gfx10_debugfs_insn(struct amdgcn_insn *insn,
 		gfx10_debugfs_exp(&insn->gfx10, m);
 		break;
 	default:
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 		break;
 	}
 }
@@ -6150,7 +6150,7 @@ static inline void gfx9_debugfs_insn(struct amdgcn_insn *insn,
 	else if (insn->size == 12)
 		seq_printf(m, "%.8X %.8X %.8X\t", ptr[0], ptr[1], ptr[2]);
 	else
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 
 	switch (insn->type) {
 	case AMDGCN_INSN_TYPE_SOP2:
@@ -6223,7 +6223,7 @@ static inline void gfx9_debugfs_insn(struct amdgcn_insn *insn,
 		gfx9_debugfs_exp(&insn->gfx9, m);
 		break;
 	default:
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 		break;
 	}
 }
@@ -6236,7 +6236,7 @@ static inline void debugfs_insn(int version, struct amdgcn_insn *insn,
 	else if (version == 9)
 		gfx9_debugfs_insn(insn, m);
 	else
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 }
 
 /*

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -127,7 +127,7 @@
 /*
  * DATA/DATA_END VGPRs: hold packet gaddr and end address.
  * Set in prologue, read by BPF ctx->data / ctx->data_end accesses.
- * Replaces GTT round-trip (prologue store → BPF load).
+ * Replaces GTT round-trip (prologue store -> BPF load).
  */
 #define KNOD_AMDGPU_DATA_VREG_LO	64
 #define KNOD_AMDGPU_DATA_VREG_HI	65
@@ -261,7 +261,7 @@
  * done_mask tracks lanes that have reached BPF_EXIT.
  * exec_save pairs store EXEC at branch points for restore at merge points.
  * GFX9: s[0:101] addressable (102 SGPRs), GFX10: s[0:105] (106 SGPRs).
- * NOTE: s[32:33] is corrupted by GFX9 hardware — do NOT use on GFX9.
+ * NOTE: s[32:33] is corrupted by GFX9 hardware - do NOT use on GFX9.
  * GFX10 uses s[32:33] for done_mask and starts exec_save at s[34].
  */
 /* Common SGPR special register indices (same on GFX9 and GFX10) */
@@ -270,7 +270,7 @@
 #define AMDGCN_SREG_INTEGER_0		128
 #define AMDGCN_SREG_INTEGER_1		129
 
-/* s[34:35] — must not overlap TMP_SREGs */
+/* s[34:35] - must not overlap TMP_SREGs */
 #define KNOD_AMDGPU_DONE_MASK_SREG	34
 #define KNOD_AMDGPU_EXEC_SAVE_SREG_BASE 36 /* s[36:37], s[38:39], ... */
 #define KNOD_AMDGPU_INITIAL_EXEC_SREG_GFX9 100
@@ -586,17 +586,17 @@ static void kfd_kernel_gfx9_init(struct knod *knod)
 	kernel_code->compute_pgm_rsrc2.reserved0 = 0;
 
 	/*
-	 * User SGPR layout — loaded in fixed order, disabled entries are
+	 * User SGPR layout - loaded in fixed order, disabled entries are
 	 * skipped (not reserved).  The resulting SGPR map depends on which
 	 * flags are enabled:
 	 *
-	 *   enable_sgpr_private_segment_buffer  → 4 SGPRs  (s[0:3])
-	 *   enable_sgpr_dispatch_ptr            → 2 SGPRs  (s[4:5])
-	 *   enable_sgpr_queue_ptr               → 2 SGPRs
-	 *   enable_sgpr_kernarg_segment_ptr     → 2 SGPRs
-	 *   enable_sgpr_dispatch_id             → 2 SGPRs
-	 *   enable_sgpr_flat_scratch_init       → 2 SGPRs
-	 *   enable_sgpr_private_segment_size    → 1 SGPR
+	 *   enable_sgpr_private_segment_buffer  -> 4 SGPRs  (s[0:3])
+	 *   enable_sgpr_dispatch_ptr            -> 2 SGPRs  (s[4:5])
+	 *   enable_sgpr_queue_ptr               -> 2 SGPRs
+	 *   enable_sgpr_kernarg_segment_ptr     -> 2 SGPRs
+	 *   enable_sgpr_dispatch_id             -> 2 SGPRs
+	 *   enable_sgpr_flat_scratch_init       -> 2 SGPRs
+	 *   enable_sgpr_private_segment_size    -> 1 SGPR
 	 *
 	 * System SGPRs (WorkgroupId etc.) follow immediately after the
 	 * last user SGPR.  user_sgpr_count must match the total above.
@@ -613,7 +613,7 @@ static void kfd_kernel_gfx9_init(struct knod *knod)
 	kernel_code->code_properties.enable_sgpr_dispatch_id = 1;
 	/* 2 SGPRs */
 	kernel_code->code_properties.enable_sgpr_flat_scratch_init = 1;
-	/* disabled → s14/s15 free for workgroup_id */
+	/* disabled -> s14/s15 free for workgroup_id */
 	kernel_code->code_properties.enable_sgpr_private_segment_size = 0;
 	/* total = 14 SGPRs */
 	kernel_code->code_properties.reserved0 = 0;
@@ -635,17 +635,17 @@ static void kfd_kernel_gfx10_init(struct knod *knod)
 	kernel_code->kernel_code_entry_byte_offset = 1024;
 
 	/*
-	 * User SGPR layout — loaded in fixed order, disabled entries are
+	 * User SGPR layout - loaded in fixed order, disabled entries are
 	 * skipped (not reserved).  The resulting SGPR map depends on which
 	 * flags are enabled:
 	 *
-	 *   enable_sgpr_private_segment_buffer  → 4 SGPRs  (s[0:3])
-	 *   enable_sgpr_dispatch_ptr            → 2 SGPRs  (s[4:5])
-	 *   enable_sgpr_queue_ptr               → 2 SGPRs
-	 *   enable_sgpr_kernarg_segment_ptr     → 2 SGPRs
-	 *   enable_sgpr_dispatch_id             → 2 SGPRs
-	 *   enable_sgpr_flat_scratch_init       → 2 SGPRs
-	 *   enable_sgpr_private_segment_size    → 1 SGPR
+	 *   enable_sgpr_private_segment_buffer  -> 4 SGPRs  (s[0:3])
+	 *   enable_sgpr_dispatch_ptr            -> 2 SGPRs  (s[4:5])
+	 *   enable_sgpr_queue_ptr               -> 2 SGPRs
+	 *   enable_sgpr_kernarg_segment_ptr     -> 2 SGPRs
+	 *   enable_sgpr_dispatch_id             -> 2 SGPRs
+	 *   enable_sgpr_flat_scratch_init       -> 2 SGPRs
+	 *   enable_sgpr_private_segment_size    -> 1 SGPR
 	 *
 	 * System SGPRs (WorkgroupId etc.) follow immediately after the
 	 * last user SGPR.  user_sgpr_count must match the total above.
@@ -662,7 +662,7 @@ static void kfd_kernel_gfx10_init(struct knod *knod)
 	kernel_code->code_properties.enable_sgpr_dispatch_id = 1;
 	/* 2 SGPRs */
 	kernel_code->code_properties.enable_sgpr_flat_scratch_init = 1;
-	/* disabled → s14/s15 free for workgroup_id */
+	/* disabled -> s14/s15 free for workgroup_id */
 	kernel_code->code_properties.enable_sgpr_private_segment_size = 0;
 	/* total = 14 SGPRs */
 	kernel_code->code_properties.reserved0 = 0;
@@ -823,7 +823,7 @@ static struct knod_bpf_work_sq *knod_prepare_bpf(struct knod_bpf_priv *priv)
 
 		/* Fill queue descriptor for GPU direct SPSC read.
 		 * ring_start is the absolute ring position where this sqw
-		 * begins — shader reads slots[(ring_start + tid) & mask].
+		 * begins - shader reads slots[(ring_start + tid) & mask].
 		 * Offset by skip to keep staged sqws disjoint.
 		 */
 		param->queues[i].pool_gaddr = knodev->wpriv[i].spsc_pool_gaddr;
@@ -911,7 +911,7 @@ static void knod_complete_acquire(struct knod_bpf_priv *priv,
 }
 
 /* Phase 2: schedule NAPI and free sqw.  Can run after the next dispatch
- * has been submitted — napi_schedule overlaps with GPU execution.
+ * has been submitted - napi_schedule overlaps with GPU execution.
  */
 static void knod_complete_napi(struct knod_bpf_priv *priv,
 			       struct knod_bpf_work_sq *sqw)
@@ -1122,7 +1122,7 @@ static int knod_bpf_jit_pass_kernel(struct knod_bpf_priv *priv)
 	knod_emit(priv, epi, global_store_dword, p[0], p[1],
 		  offsetof(struct spsc_bd, act));
 
-	/* XDP_PASS detection: v_cmp_eq_u32 XDP_PASS, R0 → VCC */
+	/* XDP_PASS detection: v_cmp_eq_u32 XDP_PASS, R0 -> VCC */
 	knod_iset32(&p[0], XDP_PASS);
 	knod_vset32(&p[1], KNOD_AMDGPU_VREG0_LO);
 	knod_emit(priv, epi, v_cmp_eq_u32, p[0], p[1]);
@@ -1130,7 +1130,7 @@ static int knod_bpf_jit_pass_kernel(struct knod_bpf_priv *priv)
 	pass_branch_idx = epi->amdgpu_insns;
 	knod_emit(priv, epi, s_cbranch_vccz, 0);
 
-	/* EXEC &= VCC — only PASS lanes proceed */
+	/* EXEC &= VCC - only PASS lanes proceed */
 	knod_emit(priv, epi, s_and_b64, AMDGCN_SREG_EXEC_LO,
 		  AMDGCN_SREG_EXEC_LO, AMDGCN_SREG_VCC_LO);
 
@@ -1143,7 +1143,7 @@ static int knod_bpf_jit_pass_kernel(struct knod_bpf_priv *priv)
 	knod_sset32(&p[1], KNOD_AMDGPU_PARAM_SREG_HI);
 	knod_emit(priv, epi, v_mov_b32_e32, p[0], p[1]);
 
-	/* v_mov v2, s15 (queue_idx → VGPR) */
+	/* v_mov v2, s15 (queue_idx -> VGPR) */
 	knod_vset32(&p[0], KNOD_AMDGPU_VREG1_LO);
 	knod_sset32(&p[1], KNOD_AMDGPU_WORKGROUP_ID_Y_SREG);
 	knod_emit(priv, epi, v_mov_b32_e32, p[0], p[1]);
@@ -1165,7 +1165,7 @@ static int knod_bpf_jit_pass_kernel(struct knod_bpf_priv *priv)
 	knod_iset32(&p[1], 1);
 	knod_emit(priv, epi, v_mov_b32_e32, p[0], p[1]);
 
-	/* global_atomic_add pass_count[q]++, GLC=1 → old_val in TMP10_LO */
+	/* global_atomic_add pass_count[q]++, GLC=1 -> old_val in TMP10_LO */
 	knod_vset32(&p[0], KNOD_AMDGPU_TMP_VREG10_LO);
 	knod_vset32(&p[1], KNOD_AMDGPU_TMP_VREG9_LO);
 	knod_vset32(&p[2], KNOD_AMDGPU_TMP_VREG10_LO);
@@ -1685,7 +1685,7 @@ static int __knod_bpf_map_alloc(struct knod_dev *knodev,
 	}
 
 	/* PERCPU_ARRAY keeps one value array per GPU workgroup (percpu
-	 * instance) so each CU updates its own copy — no cross-CU atomic
+	 * instance) so each CU updates its own copy - no cross-CU atomic
 	 * contention.  Instances map 1:1 to the per-cpu value buffer, so
 	 * allocate num_possible_cpus of them (workgroup_id_y indexes into it).
 	 */
@@ -1893,7 +1893,7 @@ knod_bpf_map_hash_alloc_elem(struct knod_bpf_map *knod_map,
 	unsafe_memcpy(knod_bpf_hash_elem_kv(e) + knod_map_obj->key_size,
 		      value, knod_map_obj->value_size,
 		      "knod hash elems are variable-sized GPU map records");
-	/* VRAM is ioremap_wc — drain new elem's next and kv stores before
+	/* VRAM is ioremap_wc - drain new elem's next and kv stores before
 	 * the caller publishes a pointer to this elem.
 	 */
 	wmb();
@@ -2029,7 +2029,7 @@ static int knod_bpf_map_hash_delete_elem(struct knod_bpf_map *knod_map,
 			unsigned int e_next = e->next & KNOD_BPF_HASH_NEXT_MASK;
 			unsigned int del_id = ((void *)e - elems) / elem_size;
 
-			/* Unlink (GPU is paused — safe) */
+			/* Unlink (GPU is paused - safe) */
 			if (pe != e)
 				pe->next = (pe->next &
 					    KNOD_BPF_HASH_NEXT_DELETED) |
@@ -2842,7 +2842,7 @@ static int knod_bpf_activate(struct knod_dev *knodev)
 	/*
 	 * Pin the module while BPF is the selected feature: the core calls
 	 * into these ops, so it must not be unloaded until feature->none.
-	 * (No-op when built in — THIS_MODULE is NULL.)
+	 * (No-op when built in - THIS_MODULE is NULL.)
 	 */
 	if (!try_module_get(THIS_MODULE))
 		return -ENODEV;
@@ -3067,7 +3067,7 @@ static int knod_bpf_check_store(struct knod_prog *knod_prog,
 	return knod_bpf_check_ptr(knod_prog, meta, env, meta->insn.dst_reg);
 }
 
-/* TODO
+/* NOTE:
  * knod_bpf_lookup_prev_meta_by_dreg(), src_reg vs dst_reg ???????/
  */
 static int knod_bpf_check_alu(struct knod_prog *knod_prog,
@@ -3779,7 +3779,7 @@ static int knod_prog_prepare_insns(struct knod_bpf_priv *priv,
 	 * at the same VRAM address is fetched from memory, not from the
 	 * stale I-cache.  Must be the very first instruction at the entry
 	 * point so that every shader version has s_icache_inv at the same
-	 * offset — the cached old version executes s_icache_inv too,
+	 * offset - the cached old version executes s_icache_inv too,
 	 * which flushes the cache before divergent code is reached.
 	 */
 	knod_emit(priv, meta, s_icache_inv);
@@ -3833,7 +3833,7 @@ static int knod_prog_prepare_insns(struct knod_bpf_priv *priv,
 	knod_emit(priv, meta, s_waitcnt_vmcnt_lgkmcnt);
 
 	/* NOTE: the bounds check `EXEC &= (tid < count)` is deferred until
-	 * after the queue descriptor load (queue↔workgroup binding).
+	 * after the queue descriptor load (queue<->workgroup binding).
 	 * nr_backlogs is no longer the right upper bound because lanes with
 	 * tid > this queue's count must be masked, not just the ones past
 	 * the aggregate backlog total.
@@ -3864,7 +3864,7 @@ static int knod_prog_prepare_insns(struct knod_bpf_priv *priv,
 	knod_iset32(&param[1], 0);
 	knod_emit(priv, meta, v_mov_b32_e32, param[0], param[1]);
 
-	/* b. Copy queue_id into TMP_VREG5_LO — separate scratch used as
+	/* b. Copy queue_id into TMP_VREG5_LO - separate scratch used as
 	 *    the v_mad src-multiplicand.  Avoids dst/src1 overlap on the
 	 *    following v_mad_u64_u32 (dst=TMP_VREG0_LO:HI).
 	 */
@@ -3894,7 +3894,7 @@ static int knod_prog_prepare_insns(struct knod_bpf_priv *priv,
 		  param[0]);
 
 	/* e. Load pool_gaddr + base_gaddr (offset 0, 16 bytes) into
-	 *    TMP_VREG1_LO..TMP_VREG2_HI (v24..v27 — must be consecutive).
+	 *    TMP_VREG1_LO..TMP_VREG2_HI (v24..v27 - must be consecutive).
 	 */
 	knod_vset32(&param[0], KNOD_AMDGPU_TMP_VREG1_LO);
 	knod_vset32(&param[1], KNOD_AMDGPU_TMP_VREG0_LO);
@@ -3987,7 +3987,7 @@ static int knod_prog_prepare_insns(struct knod_bpf_priv *priv,
 	knod_vset32(&param[2], KNOD_AMDGPU_TMP_VREG5_LO);
 	knod_emit(priv, meta, v_and_b32_e32, param[0], param[1], param[2]);
 
-	/* Save backlog index before step 6 overwrites IDX_VREG → SLOT_VREG.
+	/* Save backlog index before step 6 overwrites IDX_VREG -> SLOT_VREG.
 	 * v_mov_b32 BACKLOG_IDX_VREG(v58), IDX_VREG(v62)
 	 * Used in epilogue for XDP_PASS pass_indices[] write.
 	 */
@@ -4086,8 +4086,8 @@ static int knod_prog_prepare_insns(struct knod_bpf_priv *priv,
 	knod_emit(priv, meta, v_add_co_ci_u32_e32, param[0], param[1],
 		  param[2]);
 
-	/* Step 10 eliminated: data→DATA_VREG, data_end→DATA_END_VREG,
-	 * slot_addr→SLOT_VREG computed directly in steps 6/8/9 above.
+	/* Step 10 eliminated: data->DATA_VREG, data_end->DATA_END_VREG,
+	 * slot_addr->SLOT_VREG computed directly in steps 6/8/9 above.
 	 */
 
 	pr_debug("knod_bpf DEBUG: prologue emitted idx=%u (KNOD_META_INSNS=%d)\n",
@@ -4171,7 +4171,6 @@ static int knod_prog_prepare(struct knod_bpf_priv *priv,
 						 pkt_cache[i - 1].v + 1);
 	}
 
-	/* TODO stack init is required? */
 	knod_vset32(&stack[0], KNOD_AMDGPU_STACK_VREG0);
 	for (i = 1; i < 128; i++)
 		knod_vset32(&stack[i], stack[i - 1].v + 1);
@@ -4496,7 +4495,6 @@ static void knod_mul_hi32(struct knod_bpf_priv *priv,
 	knod_emit(priv, meta, v_mul_hi_u32, dst, src1, src2);
 }
 
-/* TODO corruption of src1, src2 */
 static void knod_mul64(struct knod_bpf_priv *priv,
 		      struct knod_insn_meta *meta,
 		      struct amdgcn_param64 dst,
@@ -5155,7 +5153,7 @@ static void knod_bpf_xdp_adjust_head(struct knod_bpf_priv *priv,
 	knod_vset32(&fail_lo, KNOD_AMDGPU_TMP_VREG2_LO);
 	knod_vset32(&fail_hi, KNOD_AMDGPU_TMP_VREG2_HI);
 
-	/* 1. Save original DATA_VREG → TMP_VREG0 */
+	/* 1. Save original DATA_VREG -> TMP_VREG0 */
 	knod_mov32(priv, meta, tmp0_lo, data_lo);
 	knod_mov32(priv, meta, tmp0_hi, data_hi);
 
@@ -5169,12 +5167,12 @@ static void knod_bpf_xdp_adjust_head(struct knod_bpf_priv *priv,
 	knod_emit(priv, meta, v_add_co_ci_u32_e32, data_hi, sext_dst,
 		  data_hi);
 
-	/* 3. Lower bound: DATA_VREG < page_base → VCC = fail */
+	/* 3. Lower bound: DATA_VREG < page_base -> VCC = fail */
 	knod_vset64(&pbase_vreg, KNOD_AMDGPU_PAGE_BASE_VREG_LO);
 	knod_emit(priv, meta, v_cmp_lt_u64, data_vreg, pbase_vreg);
 
 	/*
-	 * Capture VCC → VGPR via v_cndmask (VALU reads VCC correctly,
+	 * Capture VCC -> VGPR via v_cndmask (VALU reads VCC correctly,
 	 * unlike SALU which suffers the dual-VOPC stale-read hazard).
 	 */
 	knod_iset32(&imm, 1);
@@ -5212,8 +5210,8 @@ static void knod_bpf_xdp_adjust_head(struct knod_bpf_priv *priv,
 
 	knod_emit(priv, meta, v_cmp_lt_u32, imm, fail_lo);
 
-	/* 6. Conditional restore: VCC=1(fail) → original,
-	 *    VCC=0(pass) → adjusted
+	/* 6. Conditional restore: VCC=1(fail) -> original,
+	 *    VCC=0(pass) -> adjusted
 	 */
 	knod_emit(priv, meta, v_cndmask_b32_e32, data_lo, data_lo,
 		  tmp0_lo);
@@ -5270,7 +5268,7 @@ static void knod_bpf_xdp_adjust_tail(struct knod_bpf_priv *priv,
 	knod_vset32(&fail_hi, KNOD_AMDGPU_TMP_VREG2_HI);
 	knod_vset64(&dend_vreg, KNOD_AMDGPU_DATA_END_VREG_LO);
 
-	/* 1. Save original DATA_END_VREG → TMP_VREG0 */
+	/* 1. Save original DATA_END_VREG -> TMP_VREG0 */
 	knod_mov32(priv, meta, tmp0_lo, dend_lo);
 	knod_mov32(priv, meta, tmp0_hi, dend_hi);
 
@@ -5284,7 +5282,7 @@ static void knod_bpf_xdp_adjust_tail(struct knod_bpf_priv *priv,
 	knod_emit(priv, meta, v_add_co_ci_u32_e32, dend_hi, sext_dst,
 		  dend_hi);
 
-	/* 3. Lower bound: lb = DATA + ETH_HLEN → TMP_VREG1 */
+	/* 3. Lower bound: lb = DATA + ETH_HLEN -> TMP_VREG1 */
 	knod_vset32(&lb_lo, KNOD_AMDGPU_TMP_VREG1_LO);
 	knod_vset32(&lb_hi, KNOD_AMDGPU_TMP_VREG1_HI);
 	knod_vset32(&d_lo, KNOD_AMDGPU_DATA_VREG_LO);
@@ -5295,12 +5293,12 @@ static void knod_bpf_xdp_adjust_tail(struct knod_bpf_priv *priv,
 	knod_iset32(&imm, 0);
 	knod_emit(priv, meta, v_add_co_ci_u32_e32, lb_hi, imm, d_hi);
 
-	/* VOPC#1: DATA_END < lb → VCC = lower_fail */
+	/* VOPC#1: DATA_END < lb -> VCC = lower_fail */
 	knod_vset64(&lb, KNOD_AMDGPU_TMP_VREG1_LO);
 	knod_emit(priv, meta, v_cmp_lt_u64, dend_vreg, lb);
 
 	/*
-	 * Capture VCC → VGPR via v_cndmask (VALU reads VCC correctly,
+	 * Capture VCC -> VGPR via v_cndmask (VALU reads VCC correctly,
 	 * unlike SALU which suffers the GFX10 dual-VOPC stale-read hazard).
 	 */
 	knod_iset32(&imm, 1);
@@ -5308,7 +5306,7 @@ static void knod_bpf_xdp_adjust_tail(struct knod_bpf_priv *priv,
 	knod_iset32(&imm, 0);
 	knod_emit(priv, meta, v_cndmask_b32_e32, fail_lo, imm, fail_hi);
 
-	/* 4. Upper bound: ub = page_base + PAGE_SIZE → TMP_VREG1 */
+	/* 4. Upper bound: ub = page_base + PAGE_SIZE -> TMP_VREG1 */
 	knod_vset32(&pb_src_lo, KNOD_AMDGPU_PAGE_BASE_VREG_LO);
 	knod_vset32(&pb_src_hi, KNOD_AMDGPU_PAGE_BASE_VREG_HI);
 	knod_mov32(priv, meta, lb_lo, pb_src_lo);
@@ -5319,7 +5317,7 @@ static void knod_bpf_xdp_adjust_tail(struct knod_bpf_priv *priv,
 	knod_iset32(&imm, 0);
 	knod_emit(priv, meta, v_add_co_ci_u32_e32, lb_hi, imm, lb_hi);
 
-	/* VOPC#2: DATA_END > ub → VCC = upper_fail */
+	/* VOPC#2: DATA_END > ub -> VCC = upper_fail */
 	knod_emit(priv, meta, v_cmp_gt_u64, dend_vreg, lb);
 
 	/* Capture upper_fail via v_cndmask, combine, convert to VCC */
@@ -5330,8 +5328,8 @@ static void knod_bpf_xdp_adjust_tail(struct knod_bpf_priv *priv,
 
 	knod_emit(priv, meta, v_cmp_lt_u32, imm, fail_lo);
 
-	/* 5. Conditional restore: VCC=1(fail) → original,
-	 *    VCC=0(pass) → adjusted
+	/* 5. Conditional restore: VCC=1(fail) -> original,
+	 *    VCC=0(pass) -> adjusted
 	 */
 	knod_emit(priv, meta, v_cndmask_b32_e32, dend_lo, dend_lo,
 		  tmp0_lo);
@@ -5576,7 +5574,6 @@ static void knod_bpf_map_lookup(struct knod_bpf_priv *priv,
 	bucket_gaddr = (unsigned long)knod_map_obj_g +
 		       offsetof(struct knod_bpf_map_obj, bucket);
 
-	/* TODO key is only supporting stack */
 	knod_jit_dbg(" stack_off = %d map_id = %d\n", stack_off, map_id);
 	if (!knod_map_obj_g || !knod_map_obj_k)
 		WARN_ON_ONCE(1);
@@ -5587,7 +5584,7 @@ static void knod_bpf_map_lookup(struct knod_bpf_priv *priv,
 			       sizeof(unsigned int),
 			       512 + stack_off);
 	/* reg1 := bucket
-	 * TODO bucket_gaddr is greater than X, it breaks gpu
+	 * NOTE: bucket_gaddr is greater than X
 	 */
 	knod_iset64(&p64[0], bucket_gaddr);
 	knod_mov64(priv, meta, r64[1], p64[0]);
@@ -5605,7 +5602,7 @@ static void knod_bpf_map_lookup(struct knod_bpf_priv *priv,
 	if (knod_map_obj_k->map_type == BPF_MAP_TYPE_ARRAY ||
 	    knod_map_obj_k->map_type == BPF_MAP_TYPE_PERCPU_ARRAY) {
 		/* if (key > knod_map_obj_k.max_entries)
-		 * TODO integer
+		 * NOTE: integer
 		 */
 		knod_iset64(&p64[1], knod_map_obj_k->max_entries);
 		knod_mov64(priv, meta, r64[3], p64[1]);
@@ -5681,7 +5678,6 @@ static void knod_bpf_map_lookup(struct knod_bpf_priv *priv,
 		 * |0|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|
 		 * | | | |K|K|K|K|K|K|K|K |K |K |K |K |K |K |K |K |
 		 */
-		/* TODO key would be stack or packet */
 		while (len) {
 			if (len >= sizeof(unsigned long))
 				_len = sizeof(unsigned long);
@@ -5749,7 +5745,7 @@ static void knod_bpf_map_lookup(struct knod_bpf_priv *priv,
 
 		/* if (r64[2].lo == KNOD_BPF_HASH_NEXT_END)
 		 *	goto out;
-		 * VOPC cannot encode literal constants — move to VGPR first.
+		 * VOPC cannot encode literal constants - move to VGPR first.
 		 * NEXT_MASK == NEXT_END (0x7FFFFFFF), reuse p32 from v_and
 		 * above.
 		 */
@@ -5902,7 +5898,7 @@ static void knod_bpf_map_lookup(struct knod_bpf_priv *priv,
 
 		/* DELETED check: remove deleted lanes from match result.
 		 * r64[0].hi = elem.next (loaded in parallel with key).
-		 * Deleted elems have bit 31 set — exclude them from SREG4.
+		 * Deleted elems have bit 31 set - exclude them from SREG4.
 		 */
 		knod_iset32(&p32, KNOD_BPF_HASH_NEXT_DELETED);
 		knod_emit(priv, meta, v_and_b32_e32, r64[0].hi, p32,
@@ -5976,7 +5972,7 @@ static void knod_bpf_map_update_array(struct knod_bpf_priv *priv,
 	if (!knod_map_obj_g || !knod_map_obj_k)
 		WARN_ON_ONCE(1);
 
-	/* load key from stack → r64[2] */
+	/* load key from stack -> r64[2] */
 	knod_bpf_load_size(priv, meta,
 			       &r64[2],
 			       &stack[0],
@@ -5994,7 +5990,7 @@ static void knod_bpf_map_update_array(struct knod_bpf_priv *priv,
 	/* bpf_reg64[0] = 0 (return value) */
 	knod_mov64(priv, meta, bpf_reg64[0], p64[1]);
 
-	/* bounds check: if (key >= max_entries) → skip */
+	/* bounds check: if (key >= max_entries) -> skip */
 	knod_iset64(&p64[1], knod_map_obj_k->max_entries);
 	knod_mov64(priv, meta, r64[3], p64[1]);
 	knod_emit(priv, meta, v_cmp_ge_u64, r64[2], r64[3]);
@@ -6013,7 +6009,7 @@ static void knod_bpf_map_update_array(struct knod_bpf_priv *priv,
 	meta->amdgpu_insns++;
 	fixup_idx++;
 
-	/* dest = bucket_gaddr + key * value_size → r64[0] */
+	/* dest = bucket_gaddr + key * value_size -> r64[0] */
 	knod_iset64(&p64[1], knod_map_obj_k->value_size);
 	knod_emit(priv, meta, v_mad_u64_u32, r64[0], sr64[0].lo,
 		  p64[1].lo, r64[2].lo, r64[1]);
@@ -6142,7 +6138,7 @@ static void knod_bpf_map_update_hash(struct knod_bpf_priv *priv,
 
 	/* ======== Phase 1: Setup ======== */
 
-	/* Load key from stack → r64[3..9] (KEY_IN_PKT) */
+	/* Load key from stack -> r64[3..9] (KEY_IN_PKT) */
 	key_in_pkt = KEY_IN_PKT_64;
 	len = knod_map_obj_k->key_size;
 	off = key_stack_off;
@@ -6161,7 +6157,7 @@ static void knod_bpf_map_update_hash(struct knod_bpf_priv *priv,
 		off += _len;
 	}
 
-	/* jhash → r64[2].lo = hash */
+	/* jhash -> r64[2].lo = hash */
 	knod_jhash(priv, meta,
 		       2,
 		       knod_map_obj_k->key_size,
@@ -6178,7 +6174,7 @@ static void knod_bpf_map_update_hash(struct knod_bpf_priv *priv,
 	knod_iset64(&p64[0], bucket_gaddr);
 	knod_mov64(priv, meta, r64[1], p64[0]);
 
-	/* bucket_addr = bucket_gaddr + hash * sizeof(int) → r64[2] */
+	/* bucket_addr = bucket_gaddr + hash * sizeof(int) -> r64[2] */
 	knod_iset64(&p64[1], sizeof(int));
 	knod_emit(priv, meta, v_mad_u64_u32, r64[2], sr64[0].lo,
 		  p64[1].lo, r64[2].lo, r64[1]);
@@ -6272,7 +6268,7 @@ static void knod_bpf_map_update_hash(struct knod_bpf_priv *priv,
 	meta->amdgpu_insns++;
 	fixup_idx++;
 
-	/* Lock acquired — restore same-bucket lanes */
+	/* Lock acquired - restore same-bucket lanes */
 	knod_emit(priv, meta, s_mov_b64, AMDGCN_SREG_EXEC_LO,
 		  KNOD_AMDGPU_TMP_SREG0_LO);
 
@@ -6323,7 +6319,7 @@ static void knod_bpf_map_update_hash(struct knod_bpf_priv *priv,
 	meta->amdgpu_insns++;
 	fixup_idx++;
 
-	/* elem_addr = elems + elem_id * elem_size → r64[2] */
+	/* elem_addr = elems + elem_id * elem_size -> r64[2] */
 	knod_iset64(&p64[0], elems_gaddr);
 	knod_mov64(priv, meta, r64[1], p64[0]);
 	knod_iset64(&p64[0], elem_size);
@@ -6334,7 +6330,7 @@ static void knod_bpf_map_update_hash(struct knod_bpf_priv *priv,
 	/* Load elem.next for DELETED check */
 	knod_emit(priv, meta, global_load_dword, r64[0].hi, r64[2].lo, 0);
 
-	/* Load key from map element → KEY_IN_MAP */
+	/* Load key from map element -> KEY_IN_MAP */
 	key_in_map = KEY_IN_MAP_32;
 	len = knod_map_obj_k->key_size;
 	off = offsetof(struct knod_bpf_hash_elem_obj, kv);
@@ -6370,7 +6366,7 @@ static void knod_bpf_map_update_hash(struct knod_bpf_priv *priv,
 
 	knod_wait_vmcnt(priv, meta);
 
-	/* Key comparison → SREG1 */
+	/* Key comparison -> SREG1 */
 	key_in_map = KEY_IN_MAP_32;
 	key_in_pkt = KEY_IN_PKT_32;
 	len = knod_map_obj_k->key_size;
@@ -6577,11 +6573,11 @@ static void knod_bpf_map_update_hash(struct knod_bpf_priv *priv,
 		  r64[11].lo, 0, 1);
 	knod_wait_vmcnt(priv, meta);
 
-	/* my_cur = old_cur - 1 → r64[0].lo */
+	/* my_cur = old_cur - 1 -> r64[0].lo */
 	knod_emit(priv, meta, v_mov_b32_e32, r64[0].lo, v_one);
 	knod_emit(priv, meta, v_sub_u32, r64[0].lo, r64[11].lo, r64[0].lo);
 
-	/* OOM check: if (my_cur < 0) → skip insert */
+	/* OOM check: if (my_cur < 0) -> skip insert */
 	knod_emit(priv, meta, v_cmp_gt_i32, v_zero, r64[0].lo);
 	knod_emit(priv, meta, s_andn2_b64, AMDGCN_SREG_EXEC_LO,
 		  AMDGCN_SREG_EXEC_LO, AMDGCN_SREG_VCC_LO);
@@ -6594,18 +6590,18 @@ static void knod_bpf_map_update_hash(struct knod_bpf_priv *priv,
 	meta->amdgpu_insns++;
 	fixup_idx++;
 
-	/* queue_addr = queue_gaddr + my_cur * 4 → r64[1] */
+	/* queue_addr = queue_gaddr + my_cur * 4 -> r64[1] */
 	knod_iset64(&p64[0], queue_gaddr);
 	knod_mov64(priv, meta, r64[1], p64[0]);
 	knod_iset64(&p64[1], sizeof(unsigned int));
 	knod_emit(priv, meta, v_mad_u64_u32, r64[1], sr64_carry.lo,
 		  p64[1].lo, r64[0].lo, r64[1]);
 
-	/* elem_id = queue[my_cur] → r64[0].lo */
+	/* elem_id = queue[my_cur] -> r64[0].lo */
 	knod_emit(priv, meta, global_load_dword, r64[0].lo, r64[1].lo, 0);
 	knod_wait_vmcnt(priv, meta);
 
-	/* new_elem_addr = elems + elem_id * elem_size → r64[2] */
+	/* new_elem_addr = elems + elem_id * elem_size -> r64[2] */
 	knod_iset64(&p64[0], elems_gaddr);
 	knod_mov64(priv, meta, r64[1], p64[0]);
 	knod_iset64(&p64[0], elem_size);
@@ -6617,7 +6613,7 @@ static void knod_bpf_map_update_hash(struct knod_bpf_priv *priv,
 	knod_emit(priv, meta, v_readfirstlane_b32, KNOD_AMDGPU_TMP_SREG1_LO,
 		  r64[0].lo.v);
 
-	/* Load current bucket head → r64[1].lo */
+	/* Load current bucket head -> r64[1].lo */
 	knod_emit(priv, meta, global_load_dword, r64[1].lo, r64[15].lo, 0);
 	knod_wait_vmcnt(priv, meta);
 
@@ -6844,7 +6840,7 @@ static void knod_bpf_map_delete_hash(struct knod_bpf_priv *priv,
 
 	/* ======== Phase 1: Setup ======== */
 
-	/* Load key from stack → r64[3..9] (KEY_IN_PKT) */
+	/* Load key from stack -> r64[3..9] (KEY_IN_PKT) */
 	key_in_pkt = KEY_IN_PKT_64;
 	len = knod_map_obj_k->key_size;
 	off = key_stack_off;
@@ -6863,7 +6859,7 @@ static void knod_bpf_map_delete_hash(struct knod_bpf_priv *priv,
 		off += _len;
 	}
 
-	/* jhash → r64[2].lo = hash */
+	/* jhash -> r64[2].lo = hash */
 	knod_jhash(priv, meta,
 		       2,
 		       knod_map_obj_k->key_size,
@@ -6880,7 +6876,7 @@ static void knod_bpf_map_delete_hash(struct knod_bpf_priv *priv,
 	knod_iset64(&p64[0], bucket_gaddr);
 	knod_mov64(priv, meta, r64[1], p64[0]);
 
-	/* bucket_addr = bucket_gaddr + hash * sizeof(int) → r64[2] */
+	/* bucket_addr = bucket_gaddr + hash * sizeof(int) -> r64[2] */
 	knod_iset64(&p64[1], sizeof(int));
 	knod_emit(priv, meta, v_mad_u64_u32, r64[2], sr64[0].lo,
 		  p64[1].lo, r64[2].lo, r64[1]);
@@ -6972,7 +6968,7 @@ static void knod_bpf_map_delete_hash(struct knod_bpf_priv *priv,
 	meta->amdgpu_insns++;
 	fixup_idx++;
 
-	/* Lock acquired — restore same-bucket lanes */
+	/* Lock acquired - restore same-bucket lanes */
 	knod_emit(priv, meta, s_mov_b64, AMDGCN_SREG_EXEC_LO,
 		  KNOD_AMDGPU_TMP_SREG0_LO);
 
@@ -7023,7 +7019,7 @@ static void knod_bpf_map_delete_hash(struct knod_bpf_priv *priv,
 	meta->amdgpu_insns++;
 	fixup_idx++;
 
-	/* elem_addr = elems + elem_id * elem_size → r64[2] */
+	/* elem_addr = elems + elem_id * elem_size -> r64[2] */
 	knod_iset64(&p64[0], elems_gaddr);
 	knod_mov64(priv, meta, r64[1], p64[0]);
 	knod_iset64(&p64[0], elem_size);
@@ -7034,7 +7030,7 @@ static void knod_bpf_map_delete_hash(struct knod_bpf_priv *priv,
 	/* Load elem.next for DELETED check */
 	knod_emit(priv, meta, global_load_dword, r64[0].hi, r64[2].lo, 0);
 
-	/* Load key from map element → KEY_IN_MAP */
+	/* Load key from map element -> KEY_IN_MAP */
 	key_in_map = KEY_IN_MAP_32;
 	len = knod_map_obj_k->key_size;
 	off = offsetof(struct knod_bpf_hash_elem_obj, kv);
@@ -7070,7 +7066,7 @@ static void knod_bpf_map_delete_hash(struct knod_bpf_priv *priv,
 
 	knod_wait_vmcnt(priv, meta);
 
-	/* Key comparison → SREG1 */
+	/* Key comparison -> SREG1 */
 	key_in_map = KEY_IN_MAP_32;
 	key_in_pkt = KEY_IN_PKT_32;
 	len = knod_map_obj_k->key_size;
@@ -7168,14 +7164,14 @@ static void knod_bpf_map_delete_hash(struct knod_bpf_priv *priv,
 
 	/* ---- Match path: set DELETED + append to gc_list ---- */
 
-	/* atomic_or(elem.next, DELETED_BIT) — mark deleted */
+	/* atomic_or(elem.next, DELETED_BIT) - mark deleted */
 	knod_lset32(&v_del,
 				 KNOD_BPF_HASH_NEXT_DELETED);
 	knod_emit(priv, meta, v_mov_b32_e32, r64[11].lo, v_del);
 	knod_emit(priv, meta, global_atomic_or, r64[11].hi, r64[2].lo,
 		  r64[11].lo, 0, 0);
 
-	/* atomic_add(gc_count, 1) → old_count in r64[11].lo */
+	/* atomic_add(gc_count, 1) -> old_count in r64[11].lo */
 	knod_emit(priv, meta, v_mov_b32_e32, r64[11].lo, v_one);
 
 	knod_iset64(&p64[0], gc_count_gaddr);
@@ -7307,7 +7303,7 @@ static void knod_bpf_map_delete_array(struct knod_bpf_priv *priv,
 	if (!knod_map_obj_g || !knod_map_obj_k)
 		WARN_ON_ONCE(1);
 
-	/* load key from stack → r64[2] */
+	/* load key from stack -> r64[2] */
 	knod_bpf_load_size(priv, meta,
 			       &r64[2],
 			       &stack[0],
@@ -7325,7 +7321,7 @@ static void knod_bpf_map_delete_array(struct knod_bpf_priv *priv,
 	/* bpf_reg64[0] = 0 (return value) */
 	knod_mov64(priv, meta, bpf_reg64[0], p64[1]);
 
-	/* bounds check: if (key >= max_entries) → skip */
+	/* bounds check: if (key >= max_entries) -> skip */
 	knod_iset64(&p64[1], knod_map_obj_k->max_entries);
 	knod_mov64(priv, meta, r64[3], p64[1]);
 	knod_emit(priv, meta, v_cmp_ge_u64, r64[2], r64[3]);
@@ -7344,7 +7340,7 @@ static void knod_bpf_map_delete_array(struct knod_bpf_priv *priv,
 	meta->amdgpu_insns++;
 	fixup_idx++;
 
-	/* dest = bucket_gaddr + key * value_size → r64[0] */
+	/* dest = bucket_gaddr + key * value_size -> r64[0] */
 	knod_iset64(&p64[1], knod_map_obj_k->value_size);
 	knod_emit(priv, meta, v_mad_u64_u32, r64[0], sr64[0].lo,
 		  p64[1].lo, r64[2].lo, r64[1]);
@@ -7555,11 +7551,11 @@ static bool knod_bpf_is_retval_move_to_r0(const struct knod_insn_meta *meta);
  * structurized per-lane branching. Replaces the old s_cbranch_vccnz/vccz.
  *
  * For FORWARD_SKIP:
- *   Save jumping lanes → narrow EXEC → s_cbranch_execz
+ *   Save jumping lanes -> narrow EXEC -> s_cbranch_execz
  *   (skip if no active lanes)
  *
  * For DIRECT_EXIT:
- *   Compute exit lanes → update done_mask → remove from EXEC (no branch)
+ *   Compute exit lanes -> update done_mask -> remove from EXEC (no branch)
  *
  * Emits the required EXEC mask manipulation in-place.
  */
@@ -7608,7 +7604,7 @@ static void knod_bpf_emit_branch_tail(struct knod_bpf_priv *priv,
 	switch (meta->branch_type) {
 	case KNOD_BR_FORWARD_SKIP:
 		if (meta->jump_neg_op) {
-			/* JNE: VCC=0 → jump, VCC=1 → fall-through.
+			/* JNE: VCC=0 -> jump, VCC=1 -> fall-through.
 			 * Save jump lanes (VCC=0): s[n] = exec & ~vcc
 			 */
 			knod_emit(priv, meta, s_andn2_b64,
@@ -7622,7 +7618,7 @@ static void knod_bpf_emit_branch_tail(struct knod_bpf_priv *priv,
 				  AMDGCN_SREG_EXEC_LO,
 				  AMDGCN_SREG_VCC_LO);
 		} else {
-			/* Normal: VCC=1 → jump, VCC=0 → fall-through.
+			/* Normal: VCC=1 -> jump, VCC=0 -> fall-through.
 			 * Save jump lanes (VCC=1): s[n] = exec & vcc
 			 */
 			knod_emit(priv, meta, s_and_b64,
@@ -7643,19 +7639,19 @@ static void knod_bpf_emit_branch_tail(struct knod_bpf_priv *priv,
 		 * following block under the EXEC mask and rejoin at their merge
 		 * point.  An s_cbranch_execz skipping ahead to the merge would
 		 * jump over other scopes' merge points and strand their saved
-		 * lanes (EXEC never restored → act=0).
+		 * lanes (EXEC never restored -> act=0).
 		 */
 		break;
 
 	case KNOD_BR_DIRECT_EXIT:
 		if (meta->jump_neg_op) {
-			/* JNE: VCC=0 → exit. exit_lanes = exec & ~vcc */
+			/* JNE: VCC=0 -> exit. exit_lanes = exec & ~vcc */
 			knod_emit(priv, meta, s_andn2_b64,
 				  KNOD_AMDGPU_TMP_SREG0_LO,
 				  AMDGCN_SREG_EXEC_LO,
 				  AMDGCN_SREG_VCC_LO);
 		} else {
-			/* Normal: VCC=1 → exit. exit_lanes = exec & vcc */
+			/* Normal: VCC=1 -> exit. exit_lanes = exec & vcc */
 			knod_emit(priv, meta, s_and_b64,
 				  KNOD_AMDGPU_TMP_SREG0_LO,
 				  AMDGCN_SREG_EXEC_LO,
@@ -7686,7 +7682,7 @@ static void knod_bpf_emit_branch_tail(struct knod_bpf_priv *priv,
 		knod_emit(priv, meta, s_mov_b64, AMDGCN_SREG_EXEC_LO,
 			  KNOD_AMDGPU_TMP_SREG1_LO);
 
-		/* No branch — fall through with reduced EXEC.
+		/* No branch - fall through with reduced EXEC.
 		 * No fixup needed.
 		 */
 		meta->jmp_dst = NULL;
@@ -7708,7 +7704,7 @@ static void knod_bpf_emit_branch_tail(struct knod_bpf_priv *priv,
  * implemented).
  *
  * LLVM tail-sharing and block placement routinely emit jumps that are
- * backward in BPF byte order but are NOT loops — e.g. a UDP bounds check that
+ * backward in BPF byte order but are NOT loops - e.g. a UDP bounds check that
  * jumps back to a shared XDP_PASS tail.  Classifying those as "exit" (the
  * jmp_off < 0 heuristic in knod_bpf_analyze_cfg) silently miscompiles them:
  * the jumping lanes exit carrying whatever R0 happened to hold instead of
@@ -7718,9 +7714,9 @@ static void knod_bpf_emit_branch_tail(struct knod_bpf_priv *priv,
  *   1. partition the instruction stream into basic blocks,
  *   2. build the control-flow graph (successor edges),
  *   3. DFS for a reverse-postorder (RPO) and detect back-edges,
- *   4. no back-edges (a DAG)  → reorder blocks into RPO so every edge points
+ *   4. no back-edges (a DAG)  -> reorder blocks into RPO so every edge points
  *      forward, then classify by linear position,
- *   5. a real loop is present → bail (-EOPNOTSUPP) until loop emission lands.
+ *   5. a real loop is present -> bail (-EOPNOTSUPP) until loop emission lands.
  *
  * Loop emission (step 5) is not implemented yet, so programs containing a
  * loop are rejected with -EOPNOTSUPP.
@@ -7964,11 +7960,11 @@ static int knod_bpf_compute_rpo(struct knod_bb *bbs, int n_bbs,
 				stack[top] = s;
 				cursor[top] = 0;
 				top++;
-			} else if (s->dfs == 1) {	/* gray → back-edge */
+			} else if (s->dfs == 1) {	/* gray -> back-edge */
 				s->loop_header = true;
 				nb++;
 			}
-			/* s->dfs == 2 → forward/cross edge, nothing to do */
+			/* s->dfs == 2 -> forward/cross edge, nothing to do */
 		} else {
 			/* finished: postorder */
 			bb->dfs = 2;
@@ -7977,7 +7973,7 @@ static int knod_bpf_compute_rpo(struct knod_bb *bbs, int n_bbs,
 		}
 	}
 
-	/* postorder → reverse-postorder rank */
+	/* postorder -> reverse-postorder rank */
 	for (i = 0; i < n_bbs; i++)
 		if (bbs[i].rpo >= 0)
 			bbs[i].rpo = post - 1 - bbs[i].rpo;
@@ -8114,7 +8110,7 @@ static void knod_loop_mark_body(struct knod_bb *bbs, int n_bbs,
 /*
  * Detect natural loops from the dominator tree and report their structure.
  *
- * A back-edge is an edge u->v whose target v dominates its source u — v is
+ * A back-edge is an edge u->v whose target v dominates its source u - v is
  * the loop header, u the latch.  Its natural loop body is the header plus the
  * blocks that reach the latch without passing through the header; an exit edge
  * leaves a body block for a non-body block.
@@ -8161,7 +8157,7 @@ static int knod_bpf_detect_loops(struct knod_bb *bbs, int n_bbs)
 	kfree(stack);
 
 	if (n_be)
-		pr_info("knod_loop: %d back-edge(s) — %s\n", n_be,
+		pr_info("knod_loop: %d back-edge(s) - %s\n", n_be,
 			n_be == 1 ? "single loop (simple-shape candidate)" :
 				    "nested/multiple loops (complex)");
 	return 0;
@@ -8185,7 +8181,7 @@ static struct knod_bb *knod_bb_fall_succ(struct knod_bb *bb)
  * edge points forward, and splice in a synthetic BPF_JA wherever a block's
  * not-taken successor no longer follows it in list order.  After this the
  * emitter's forward-only machinery (FORWARD_SKIP / FORWARD_GOTO) handles the
- * whole program — including the backward-in-byte-order, non-loop jumps that
+ * whole program - including the backward-in-byte-order, non-loop jumps that
  * the old jmp_off < 0 heuristic miscompiled.
  *
  * Loops (back-edges) are rejected with -EOPNOTSUPP until loop emission lands.
@@ -8199,7 +8195,7 @@ static int knod_bpf_reorder_rpo(struct knod_prog *knod_prog,
 	LIST_HEAD(new_list);
 
 	if (n_back) {
-		pr_warn("knod_cfg: %d loop back-edge(s) — block reorder cannot lower loops yet (-EOPNOTSUPP)\n",
+		pr_warn("knod_cfg: %d loop back-edge(s) - block reorder cannot lower loops yet (-EOPNOTSUPP)\n",
 			n_back);
 		return -EOPNOTSUPP;
 	}
@@ -8269,7 +8265,7 @@ static int knod_bpf_reorder_rpo(struct knod_prog *knod_prog,
 /*
  * Classify branches by linear position after the RPO reorder.  Every edge is
  * now forward, so a conditional jump is FORWARD_SKIP (or DIRECT_EXIT when it
- * targets the exit), and every BPF_JA — real or synthetic — is FORWARD_GOTO
+ * targets the exit), and every BPF_JA - real or synthetic - is FORWARD_GOTO
  * (or DIRECT_EXIT).
  */
 static int knod_bpf_classify_linear(struct knod_prog *knod_prog)
@@ -8385,7 +8381,7 @@ out_free:
 /*
  * Assign exec_save SGPR pairs to the forward branches, recycling a pair once
  * its merge point has been passed.  The peak concurrent live count is the
- * actual SGPR requirement — usually far less than the total branch count.
+ * actual SGPR requirement - usually far less than the total branch count.
  */
 static int knod_bpf_alloc_exec_sregs(struct knod_bpf_priv *priv,
 				     struct knod_prog *knod_prog)
@@ -8450,14 +8446,14 @@ static int knod_bpf_alloc_exec_sregs(struct knod_bpf_priv *priv,
  * structurized CFG.
  *
  * Runs before instruction emission. For each conditional branch:
- *   - Backward jump or jump to EXIT → DIRECT_EXIT (no SGPR needed)
- *   - Forward jump to non-EXIT → FORWARD_SKIP, allocate SGPR pair
+ *   - Backward jump or jump to EXIT -> DIRECT_EXIT (no SGPR needed)
+ *   - Forward jump to non-EXIT -> FORWARD_SKIP, allocate SGPR pair
  *
  * The "save jumping lanes" pattern handles crossing scopes correctly:
  *   branch: s_and_b64 s[n], exec, vcc; s_andn2_b64 exec, exec, vcc
  *   merge:  s_or_b64 exec, exec, s[n]
  *
- * For JNE (jump_neg_op): VCC=0 → jump, so lanes are swapped.
+ * For JNE (jump_neg_op): VCC=0 -> jump, so lanes are swapped.
  */
 static int knod_bpf_analyze_cfg(struct knod_bpf_priv *priv,
 				struct knod_prog *knod_prog)
@@ -8498,7 +8494,7 @@ static void knod_emit_pass_addr_store(struct knod_bpf_priv *priv,
 {
 	struct amdgcn_param32 p[3];
 
-	/* s_lshl_b32 s18, s15, 3 — queue_idx * 8 for pass_meta_buf_gaddr
+	/* s_lshl_b32 s18, s15, 3 - queue_idx * 8 for pass_meta_buf_gaddr
 	 * stride
 	 */
 	knod_sset32(&p[0], KNOD_AMDGPU_TMP_SREG1_LO);
@@ -8610,12 +8606,11 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 	knod_prog->max_stack_off = -knod_prog->max_stack_off;
 	knod_prog->max_stack_off = ALIGN(knod_prog->max_stack_off, 4);
 	knod_prog->max_packet_off = ALIGN(knod_prog->max_packet_off, 4);
-	/* TODO
+	/* NOTE:
 	 * packet is accessed with packet_off + size
 	 * largest size of it is unsigned long
 	 */
 	knod_prog->max_packet_off += sizeof(unsigned long);
-	/* TODO refer to stack size */
 	if (knod_prog->max_packet_off > MAX_PACKET_CACHE) {
 		WARN_ON_ONCE(1);
 		knod_bpf_pkt_cache = 0;
@@ -8644,7 +8639,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 	if (knod_bpf_pkt_cache) {
 		meta = knod_prog_pre_last_meta(knod_prog);
 
-		/* ctx->data is in DATA_VREG â copy to r32[0] via v_mov */
+		/* ctx->data is in DATA_VREG -> copy to r32[0] via v_mov */
 		knod_vset32(&param[0], r32[0].v);
 		knod_vset32(&param[1], KNOD_AMDGPU_DATA_VREG_LO);
 		knod_emit(priv, meta, v_mov_b32_e32, param[0], param[1]);
@@ -8824,7 +8819,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 			knod_iset32(&p32[0], imm);
 			knod_add32(priv, meta, bpf_reg64[d].lo,
 				       p32[0], bpf_reg64[d].lo);
-			/* TODO
+			/* NOTE:
 			 * imm is 24bit.
 			 * But should we set hi to 0?
 			 */
@@ -8859,7 +8854,6 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 			//r[d] *= r[s];
 			knod_mov64(priv, meta, r64[0], bpf_reg64[d]);
 			knod_mov64(priv, meta, r64[1], bpf_reg64[s]);
-			/* TODO knod_mul64 source register value corruption */
 			knod_mul64(priv, meta,
 				       bpf_reg64[d],
 				       r64[0],
@@ -9466,7 +9460,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 			 * For CMPXCHG/FETCH: drain pending loads so addr/data
 			 * VGPRs are ready. For non-fetch ADD wave reduction,
 			 * addr was already waited for at map_lookup, and data
-			 * is from ALU — no waitcnt needed.
+			 * is from ALU - no waitcnt needed.
 			 */
 			if (imm == BPF_CMPXCHG || fetch)
 				knod_wait_vmcnt(priv, meta);
@@ -9602,7 +9596,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 				knod_emit(priv, meta, v_mbcnt_hi_u32_b32,
 					  v_tmp2, s_exec_hi, v_tmp2);
 
-				/* v_cmp_eq_u32 vcc, 0, v_tmp2 →
+				/* v_cmp_eq_u32 vcc, 0, v_tmp2 ->
 				 * first active lane
 				 */
 				knod_emit(priv, meta, v_cmp_eq_u32, v_zero,
@@ -10715,7 +10709,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 	knod_emit(priv, meta, v_mov_b32_e32, p[0], p[1]);
 
 	/* Per-queue pass_count: offset TMP_VREG9 by queue_idx * 4 */
-	/* v_mov_b32 v2, s15 (queue_idx → VGPR) */
+	/* v_mov_b32 v2, s15 (queue_idx -> VGPR) */
 	knod_vset32(&p[0], KNOD_AMDGPU_VREG1_LO);
 	knod_sset32(&p[1],
 				 KNOD_AMDGPU_WORKGROUP_ID_Y_SREG);
@@ -11040,7 +11034,7 @@ static int bpf_debugfs_insn_tagged(struct knod_bpf_priv *priv,
 /*
  * Print the instructions a second time, re-sorted into BPF source order so the
  * dump reads like the program.  The offsets are the real (reordered) GPU
- * offsets, so they appear out of sequence — that shows where the reorder
+ * offsets, so they appear out of sequence - that shows where the reorder
  * placed each block.  Synthetic jumps have no BPF source insn and are last.
  */
 static void bpf_insn_show_bpf_order(struct knod_bpf_priv *priv,
@@ -11118,7 +11112,7 @@ static int bpf_insn_show(struct seq_file *m, void *v)
 		}
 	}
 
-	/* Emission (RPO) order — the actual GPU layout.  Each line is tagged
+	/* Emission (RPO) order - the actual GPU layout.  Each line is tagged
 	 * with its origin BPF insn since the reorder makes this differ from the
 	 * BPF byte order; synthetic jumps inserted by the reorder have none.
 	 */

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -1520,7 +1520,7 @@ static void knod_setup_bpf_prog(struct bpf_prog *prog)
 						debug_ptr[0],
 						debug_ptr[1], debug_ptr[2]);
 				} else {
-					WARN_ON(1);
+					WARN_ON_ONCE(1);
 				}
 			}
 		}
@@ -1547,7 +1547,7 @@ static void knod_setup_bpf_prog(struct bpf_prog *prog)
 						debug_ptr[0],
 						debug_ptr[1], debug_ptr[2]);
 				} else {
-					WARN_ON(1);
+					WARN_ON_ONCE(1);
 				}
 			}
 		}
@@ -1570,7 +1570,7 @@ static void knod_setup_bpf_prog(struct bpf_prog *prog)
 						debug_ptr[0],
 						debug_ptr[1], debug_ptr[2]);
 				} else {
-					WARN_ON(1);
+					WARN_ON_ONCE(1);
 				}
 			}
 		}
@@ -1715,7 +1715,7 @@ static int __knod_bpf_map_alloc(struct knod_dev *knodev,
 	knod_map->offmap = offmap;
 	knod_map->priv = priv;
 	if (offmap->dev_priv)
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	offmap->dev_priv = knod_map;
 
 	knod_map_obj = (struct knod_bpf_map_obj *)mem->kaddr;
@@ -5368,11 +5368,11 @@ static void knod_bpf_load_size(struct knod_bpf_priv *priv,
 			knod_mov32(priv, meta, dst->hi,
 				       cache[(off / 4) + 1]);
 		} else if ((off % 4) == 1) {
-			WARN_ON(1);
+			WARN_ON_ONCE(1);
 		} else if ((off % 4) == 2) {
-			WARN_ON(1);
+			WARN_ON_ONCE(1);
 		} else {
-			WARN_ON(1);
+			WARN_ON_ONCE(1);
 		}
 		break;
 	case sizeof(unsigned int):
@@ -5441,7 +5441,7 @@ static void knod_bpf_load_size(struct knod_bpf_priv *priv,
 			       p32[1]);
 		break;
 	default:
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 		break;
 	}
 
@@ -5579,7 +5579,7 @@ static void knod_bpf_map_lookup(struct knod_bpf_priv *priv,
 	/* TODO key is only supporting stack */
 	knod_jit_dbg(" stack_off = %d map_id = %d\n", stack_off, map_id);
 	if (!knod_map_obj_g || !knod_map_obj_k)
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 
 	knod_bpf_load_size(priv, meta,
 			       &r64[2],
@@ -5949,7 +5949,7 @@ static void knod_bpf_map_lookup(struct knod_bpf_priv *priv,
 			knod_bpf_fixup_branch(priv, &fixups[idx]);
 
 	} else {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -5974,7 +5974,7 @@ static void knod_bpf_map_update_array(struct knod_bpf_priv *priv,
 		       offsetof(struct knod_bpf_map_obj, bucket);
 
 	if (!knod_map_obj_g || !knod_map_obj_k)
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 
 	/* load key from stack → r64[2] */
 	knod_bpf_load_size(priv, meta,
@@ -6138,7 +6138,7 @@ static void knod_bpf_map_update_hash(struct knod_bpf_priv *priv,
 	elem_size = knod_map_obj_k->meta.hmeta.elem_size;
 
 	if (!knod_map_obj_g || !knod_map_obj_k)
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 
 	/* ======== Phase 1: Setup ======== */
 
@@ -6840,7 +6840,7 @@ static void knod_bpf_map_delete_hash(struct knod_bpf_priv *priv,
 	elem_size = knod_map_obj_k->meta.hmeta.elem_size;
 
 	if (!knod_map_obj_g || !knod_map_obj_k)
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 
 	/* ======== Phase 1: Setup ======== */
 
@@ -7305,7 +7305,7 @@ static void knod_bpf_map_delete_array(struct knod_bpf_priv *priv,
 		       offsetof(struct knod_bpf_map_obj, bucket);
 
 	if (!knod_map_obj_g || !knod_map_obj_k)
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 
 	/* load key from stack → r64[2] */
 	knod_bpf_load_size(priv, meta,
@@ -7426,11 +7426,11 @@ static void knod_bpf_store_cache_size(struct knod_bpf_priv *priv,
 				       cache[(off / 4) + 1],
 				       src->hi);
 		} else if ((off % 4) == 1) {
-			WARN_ON(1);
+			WARN_ON_ONCE(1);
 		} else if ((off % 4) == 2) {
-			WARN_ON(1);
+			WARN_ON_ONCE(1);
 		} else {
-			WARN_ON(1);
+			WARN_ON_ONCE(1);
 		}
 		break;
 	case sizeof(unsigned int):
@@ -7543,7 +7543,7 @@ static void knod_bpf_store_cache_size(struct knod_bpf_priv *priv,
 			       cache[off / 4]);
 		break;
 	default:
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	}
 }
 
@@ -7693,7 +7693,7 @@ static void knod_bpf_emit_branch_tail(struct knod_bpf_priv *priv,
 		break;
 
 	default:
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 		break;
 	}
 }
@@ -8617,7 +8617,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 	knod_prog->max_packet_off += sizeof(unsigned long);
 	/* TODO refer to stack size */
 	if (knod_prog->max_packet_off > MAX_PACKET_CACHE) {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 		knod_bpf_pkt_cache = 0;
 	}
 
@@ -8907,7 +8907,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 			break;
 		case BPF_ALU64 | BPF_NEG:
 			//r[d] = -r[d];
-			WARN_ON(1);
+			WARN_ON_ONCE(1);
 			break;
 		case BPF_ALU | BPF_LSH | BPF_X:
 			knod_lshlrev32(priv, meta, bpf_reg64[d].lo,
@@ -9008,7 +9008,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 						   imm64);
 				break;
 			default:
-				WARN_ON(1);
+				WARN_ON_ONCE(1);
 				break;
 			}
 			break;
@@ -9021,7 +9021,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 		case BPF_LD | BPF_IND | BPF_W:
 			//err = pc | 0x0700;
 			//exit = true;
-			WARN_ON(1);
+			WARN_ON_ONCE(1);
 			break;
 		case BPF_LDX | BPF_MEM | BPF_B:
 			if (meta->ptr.type == PTR_TO_STACK) {
@@ -9058,7 +9058,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 						  bpf_reg64[s].lo, off);
 				}
 			} else {
-				WARN_ON(1);
+				WARN_ON_ONCE(1);
 			}
 			knod_wait_vmcnt(priv, meta);
 			knod_iset32(&p32[0], 0);
@@ -9114,7 +9114,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 				}
 			} else {
 				knod_jit_err(" type = %d\n", meta->ptr.type);
-				WARN_ON(1);
+				WARN_ON_ONCE(1);
 			}
 			//ptr = (__global void *)r[s] + off;
 			//r[d] = *(__global unsigned short *)ptr;
@@ -9195,7 +9195,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 						  bpf_reg64[s].lo, off);
 				}
 			} else {
-				WARN_ON(1);
+				WARN_ON_ONCE(1);
 			}
 			//ptr = (__global void *)r[s] + off;
 			//r[d] = *(__global unsigned int *)ptr;
@@ -9275,7 +9275,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 						  bpf_reg64[s].lo, off);
 				}
 			} else {
-				WARN_ON(1);
+				WARN_ON_ONCE(1);
 			}
 			//ptr = (__global void *)r[s] + off;
 			//r[d] = *(__global unsigned long *)ptr;
@@ -9317,7 +9317,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 						  bpf_reg64[d].lo, off);
 				}
 			} else {
-				WARN_ON(1);
+				WARN_ON_ONCE(1);
 			}
 			break;
 		case BPF_STX | BPF_MEM | BPF_H:
@@ -9357,7 +9357,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 						  bpf_reg64[d].lo, off);
 				}
 			} else {
-				WARN_ON(1);
+				WARN_ON_ONCE(1);
 			}
 			break;
 		case BPF_STX | BPF_MEM | BPF_W:
@@ -9397,7 +9397,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 						  bpf_reg64[d].lo, off);
 				}
 			} else {
-				WARN_ON(1);
+				WARN_ON_ONCE(1);
 			}
 			break;
 		case BPF_STX | BPF_MEM | BPF_DW:
@@ -9436,7 +9436,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 						  bpf_reg64[d].lo, off);
 				}
 			} else {
-				WARN_ON(1);
+				WARN_ON_ONCE(1);
 			}
 			break;
 		case BPF_STX | BPF_ATOMIC | BPF_W:
@@ -9797,7 +9797,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 						  bpf_reg64[d].lo, off);
 				}
 			} else {
-				WARN_ON(1);
+				WARN_ON_ONCE(1);
 			}
 			break;
 		case BPF_ST | BPF_MEM | BPF_H:
@@ -9836,7 +9836,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 						  bpf_reg64[d].lo, off);
 				}
 			} else {
-				WARN_ON(1);
+				WARN_ON_ONCE(1);
 			}
 			break;
 		case BPF_ST | BPF_MEM | BPF_W:
@@ -9875,7 +9875,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 						  bpf_reg64[d].lo, off);
 				}
 			} else {
-				WARN_ON(1);
+				WARN_ON_ONCE(1);
 			}
 			break;
 		case BPF_ST | BPF_MEM | BPF_DW:
@@ -9915,7 +9915,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 				}
 				knod_iset32(&p32[0], imm);
 			} else {
-				WARN_ON(1);
+				WARN_ON_ONCE(1);
 			}
 			break;
 		case BPF_JMP32 | BPF_JA | BPF_K:
@@ -9947,7 +9947,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 				/* Reorder classifies every JA as FORWARD_GOTO
 				 * or DIRECT_EXIT; reaching here is a bug.
 				 */
-				WARN_ON(1);
+				WARN_ON_ONCE(1);
 			}
 			break;
 		case BPF_JMP | BPF_JA | BPF_K:
@@ -9979,7 +9979,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 				/* Reorder classifies every JA as FORWARD_GOTO
 				 * or DIRECT_EXIT; reaching here is a bug.
 				 */
-				WARN_ON(1);
+				WARN_ON_ONCE(1);
 			}
 			break;
 		case BPF_JMP32 | BPF_JEQ | BPF_K:
@@ -10449,7 +10449,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 			switch (imm) {
 			case 1:
 				if (map_id == -1) {
-					WARN_ON(1);
+					WARN_ON_ONCE(1);
 					break;
 				}
 				knod_bpf_map_lookup(priv, meta, map_id);
@@ -10459,12 +10459,12 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 				struct knod_bpf_map_obj *_map_obj;
 
 				if (map_id == -1) {
-					WARN_ON(1);
+					WARN_ON_ONCE(1);
 					break;
 				}
 				_map_obj = knod_bpf_map_kaddr(priv, map_id);
 				if (!_map_obj) {
-					WARN_ON(1);
+					WARN_ON_ONCE(1);
 					break;
 				}
 				if (_map_obj->map_type == BPF_MAP_TYPE_ARRAY)
@@ -10475,7 +10475,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 					knod_bpf_map_update_hash(priv, meta,
 						map_id);
 				else
-					WARN_ON(1);
+					WARN_ON_ONCE(1);
 				map_id = -1;
 				break;
 			}
@@ -10483,12 +10483,12 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 				struct knod_bpf_map_obj *_map_obj;
 
 				if (map_id == -1) {
-					WARN_ON(1);
+					WARN_ON_ONCE(1);
 					break;
 				}
 				_map_obj = knod_bpf_map_kaddr(priv, map_id);
 				if (!_map_obj) {
-					WARN_ON(1);
+					WARN_ON_ONCE(1);
 					break;
 				}
 				if (_map_obj->map_type == BPF_MAP_TYPE_ARRAY)
@@ -10499,7 +10499,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 					knod_bpf_map_delete_hash(priv, meta,
 						map_id);
 				else
-					WARN_ON(1);
+					WARN_ON_ONCE(1);
 				map_id = -1;
 				break;
 			}
@@ -10513,7 +10513,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 				knod_bpf_xdp_adjust_tail(priv, meta);
 				break;
 			default:
-				WARN_ON(1);
+				WARN_ON_ONCE(1);
 				break;
 			}
 			break;
@@ -10594,7 +10594,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 				break;
 			}
 			default:
-				WARN_ON(1);
+				WARN_ON_ONCE(1);
 				break;
 			}
 			break;
@@ -10623,13 +10623,13 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 			case 64:
 				break;
 			default:
-				WARN_ON(1);
+				WARN_ON_ONCE(1);
 				break;
 			}
 			break;
 		}
 		default:
-			WARN_ON(1);
+			WARN_ON_ONCE(1);
 			break;
 		}
 
@@ -10963,7 +10963,7 @@ static int knod_bpf_xdp_install(struct knod_dev *knodev,
 
 	switch (bpf->command) {
 	case XDP_SETUP_PROG:
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 		break;
 	case XDP_SETUP_PROG_HW:
 		err = knod_bpf_setup_prog_hw_checks(knodev, bpf);
@@ -10999,7 +10999,7 @@ static inline int bpf_debugfs_insn(struct knod_bpf_priv *priv,
 	else if (priv->isa_version == 9)
 		gfx9_debugfs_insn(insn, m);
 	else
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 
 	return insn->size;
 }

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -5777,7 +5777,7 @@ static void knod_bpf_map_lookup(struct knod_bpf_priv *priv,
 
 		key_in_map = KEY_IN_MAP_32;
 		len = knod_map_obj_k->key_size;
-		off = offsetof(struct knod_bpf_hash_elem_obj, kv); /* TODO */
+		off = offsetof(struct knod_bpf_hash_elem_obj, kv);
 
 		/* elem = &elems[elem_id]; */
 		emit_v_mad_u64_u32(priv->isa_version,

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_gfx10_insn.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_gfx10_insn.h
@@ -2084,7 +2084,7 @@ inline u32 emit_gfx10_v_mov_b32_e32(union amdgcn_gfx10_insn *insn,
 				    struct amdgcn_param32 src)
 {
 	if (dst.type != AMDGCN_PARAM_TYPE_VGPR)
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	insn->vop1.encoding = GFX10_VOP1_ENCODING;
 	insn->vop1.vdst = dst.v;
 	insn->vop1.op = GFX10_V_MOV_B32;

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_gfx10_insn.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_gfx10_insn.h
@@ -1544,7 +1544,7 @@ enum amdgcn_gfx10_mubuf_opcode {
 	GFX10_BUFFER_ATOMIC_SUB = 51,
 	GFX10_BUFFER_ATOMIC_CSUB = 52,
 	GFX10_BUFFER_ATOMIC_SMIN = 53,
-	GFX10_BUFFER_ATOMIC_UMIN = 54, /* was 58 — BUG FIX (ISA p.212) */
+	GFX10_BUFFER_ATOMIC_UMIN = 54, /* was 58 - BUG FIX (ISA p.212) */
 	GFX10_BUFFER_ATOMIC_SMAX = 55,
 	GFX10_BUFFER_ATOMIC_UMAX = 56,
 	GFX10_BUFFER_ATOMIC_AND = 57,
@@ -1829,7 +1829,7 @@ union amdgcn_gfx10_insn {
 	struct amdgcn_gfx10_exp exp;
 };
 
-/* Cast macro — convert u32 *buf position to GFX10 insn union pointer. */
+/* Cast macro - convert u32 *buf position to GFX10 insn union pointer. */
 #define I10(buf, n)	((union amdgcn_gfx10_insn *)&(buf)[(n)])
 
 inline u32 gfx10_get_param_base(struct amdgcn_param32 param)
@@ -3495,7 +3495,7 @@ inline u32 emit_gfx10_s_andn2_b64(union amdgcn_gfx10_insn *insn,
 	return 4;
 }
 
-/* s_cbranch_execz off — branch if EXEC == 0 */
+/* s_cbranch_execz off - branch if EXEC == 0 */
 inline u32 emit_gfx10_s_cbranch_execz(union amdgcn_gfx10_insn *insn,
 				       short off)
 {
@@ -3506,7 +3506,7 @@ inline u32 emit_gfx10_s_cbranch_execz(union amdgcn_gfx10_insn *insn,
 	return 4;
 }
 
-/* s_cbranch_execnz off — branch if EXEC != 0 */
+/* s_cbranch_execnz off - branch if EXEC != 0 */
 inline u32 emit_gfx10_s_cbranch_execnz(union amdgcn_gfx10_insn *insn,
 					short off)
 {
@@ -3517,7 +3517,7 @@ inline u32 emit_gfx10_s_cbranch_execnz(union amdgcn_gfx10_insn *insn,
 	return 4;
 }
 
-/* s_sub_u32 sdst, ssrc0, ssrc1 — sdst = ssrc0 - ssrc1; SCC = borrow */
+/* s_sub_u32 sdst, ssrc0, ssrc1 - sdst = ssrc0 - ssrc1; SCC = borrow */
 inline u32 emit_gfx10_s_sub_u32(union amdgcn_gfx10_insn *insn,
 				 u8 sdst, u8 ssrc0, u8 ssrc1)
 {
@@ -3530,7 +3530,7 @@ inline u32 emit_gfx10_s_sub_u32(union amdgcn_gfx10_insn *insn,
 	return 4;
 }
 
-/* s_cbranch_scc0 off — branch if SCC == 0 (no borrow) */
+/* s_cbranch_scc0 off - branch if SCC == 0 (no borrow) */
 inline u32 emit_gfx10_s_cbranch_scc0(union amdgcn_gfx10_insn *insn,
 				      short off)
 {
@@ -3790,7 +3790,7 @@ DEFINE_GFX10_SMEM_P(s_load_dwordx4, GFX10_S_LOAD_DWORDX4)
 
 #undef DEFINE_GFX10_SMEM_P
 
-/* s_dcache_inv — no operands */
+/* s_dcache_inv - no operands */
 inline u32 emit_gfx10_s_dcache_inv(union amdgcn_gfx10_insn *insn)
 {
 	insn->smem.sdata = 0;

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_gfx9_insn.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_gfx9_insn.h
@@ -2010,7 +2010,7 @@ inline u32 emit_gfx9_v_mov_b32_e32(union amdgcn_gfx9_insn *insn,
 				   struct amdgcn_param32 src)
 {
 	if (dst.type != AMDGCN_PARAM_TYPE_VGPR)
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 	insn->vop1.encoding = GFX9_VOP1_ENCODING;
 	insn->vop1.vdst = dst.v;
 	insn->vop1.op = GFX9_V_MOV_B32;
@@ -2101,7 +2101,7 @@ inline u32 emit_gfx9_v_addc_co_u32(union amdgcn_gfx9_insn *insn,
 	insn->vop2.op = GFX9_V_ADDC_CO_U32;
 	insn->vop2.encoding = GFX9_VOP2_ENCODING;
 	if (src0.type == AMDGCN_PARAM_TYPE_LITERAL_CONST) {
-		WARN_ON(1);
+		WARN_ON_ONCE(1);
 		insn->vop2.src0 = gfx9_get_param_base(src0);
 		insn->vop2.literal = src0.v;
 		return 8;

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_gfx9_insn.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_gfx9_insn.h
@@ -1731,7 +1731,7 @@ union amdgcn_gfx9_insn {
 	struct amdgcn_gfx9_exp exp;
 };
 
-/* Cast macro — convert u32 *buf position to GFX9 insn union pointer. */
+/* Cast macro - convert u32 *buf position to GFX9 insn union pointer. */
 #define I9(buf, n)	((union amdgcn_gfx9_insn *)&(buf)[(n)])
 
 inline u32 gfx9_get_param_base(struct amdgcn_param32 param)
@@ -3638,7 +3638,7 @@ inline u32 emit_gfx9_s_andn2_b32(union amdgcn_gfx9_insn *insn,
 	return 4;
 }
 
-/* s_cbranch_execz off — branch if EXEC == 0 */
+/* s_cbranch_execz off - branch if EXEC == 0 */
 inline u32 emit_gfx9_s_cbranch_execz(union amdgcn_gfx9_insn *insn,
 				      short off)
 {
@@ -3649,7 +3649,7 @@ inline u32 emit_gfx9_s_cbranch_execz(union amdgcn_gfx9_insn *insn,
 	return 4;
 }
 
-/* s_cbranch_execnz off — branch if EXEC != 0 */
+/* s_cbranch_execnz off - branch if EXEC != 0 */
 inline u32 emit_gfx9_s_cbranch_execnz(union amdgcn_gfx9_insn *insn,
 				       short off)
 {
@@ -3660,7 +3660,7 @@ inline u32 emit_gfx9_s_cbranch_execnz(union amdgcn_gfx9_insn *insn,
 	return 4;
 }
 
-/* s_sub_u32 sdst, ssrc0, ssrc1 — sdst = ssrc0 - ssrc1; SCC = borrow */
+/* s_sub_u32 sdst, ssrc0, ssrc1 - sdst = ssrc0 - ssrc1; SCC = borrow */
 inline u32 emit_gfx9_s_sub_u32(union amdgcn_gfx9_insn *insn,
 				u8 sdst, u8 ssrc0, u8 ssrc1)
 {
@@ -3673,7 +3673,7 @@ inline u32 emit_gfx9_s_sub_u32(union amdgcn_gfx9_insn *insn,
 	return 4;
 }
 
-/* s_cbranch_scc0 off — branch if SCC == 0 (no borrow) */
+/* s_cbranch_scc0 off - branch if SCC == 0 (no borrow) */
 inline u32 emit_gfx9_s_cbranch_scc0(union amdgcn_gfx9_insn *insn,
 				     short off)
 {
@@ -3954,7 +3954,7 @@ DEFINE_GFX9_SMEM_P(s_load_dwordx8, GFX9_S_LOAD_DWORDX8)
 
 #undef DEFINE_GFX9_SMEM_P
 
-/* s_dcache_inv — no operands, just opcode + encoding */
+/* s_dcache_inv - no operands, just opcode + encoding */
 inline u32 emit_gfx9_s_dcache_inv(union amdgcn_gfx9_insn *insn)
 {
 	insn->smem.sdata = 0;
@@ -4026,7 +4026,7 @@ inline u32 emit_gfx9_ds_read_b32_off(union amdgcn_gfx9_insn *insn,
 	return 8;
 }
 
-/* ds_write_b128 v<addr>, v[<data>:<data>+3] — write 128 bits to LDS */
+/* ds_write_b128 v<addr>, v[<data>:<data>+3] - write 128 bits to LDS */
 inline u32 emit_gfx9_ds_write_b128(union amdgcn_gfx9_insn *insn,
 				    int addr, int data0)
 {
@@ -4034,7 +4034,7 @@ inline u32 emit_gfx9_ds_write_b128(union amdgcn_gfx9_insn *insn,
 	return 8;
 }
 
-/* ds_read_b128 v[<vdst>:<vdst>+3], v<addr> — read 128 bits from LDS */
+/* ds_read_b128 v[<vdst>:<vdst>+3], v<addr> - read 128 bits from LDS */
 inline u32 emit_gfx9_ds_read_b128(union amdgcn_gfx9_insn *insn,
 				   int vdst, int addr)
 {
@@ -4042,7 +4042,7 @@ inline u32 emit_gfx9_ds_read_b128(union amdgcn_gfx9_insn *insn,
 	return 8;
 }
 
-/* v_max_i32 vdst, src0, vsrc1 — VOP2 */
+/* v_max_i32 vdst, src0, vsrc1 - VOP2 */
 inline u32 emit_gfx9_v_max_i32(union amdgcn_gfx9_insn *insn,
 				struct amdgcn_param32 dst,
 				struct amdgcn_param32 src0,

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_ipsec.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_ipsec.c
@@ -4046,7 +4046,7 @@ static int knod_ipsec_insn_show(struct seq_file *s, void *v)
 	}
 
 	if (ndw == 1 && code[0] == 0xBF810000)
-		seq_puts(s, "\n(note: placeholder s_endpgm — real fused RX shader is TODO)\n");
+		seq_puts(s, "\n(empty shader: single s_endpgm)\n");
 
 	return 0;
 }

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_ipsec.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_ipsec.c
@@ -205,7 +205,7 @@ static void knod_gcm_precompute_h_table(const u8 *key, int key_len,
 /* Single AQL queue on purpose: CPU parallelism is provided by per-queue
  * double-buffering through `nr_aql_ring` slots inside this one queue, not
  * by multiple AQL queues. Multiple AQL queues cause ordering / contention
- * issues with the fused RX dispatch path — stick to one.
+ * issues with the fused RX dispatch path - stick to one.
  */
 /*
  * Dispatcher idle strategy toggle. Exposed as a debugfs toggle
@@ -221,7 +221,7 @@ static void knod_gcm_precompute_h_table(const u8 *key, int key_len,
  *   one CPU core at 100% even when no traffic is flowing, but removes
  *   the handoff latency entirely.
  *
- * GPU completion wait (knod_ipsec_dispatch_and_wait) is always polled —
+ * GPU completion wait (knod_ipsec_dispatch_and_wait) is always polled -
  * this switch only affects the between-dispatch idle path.
  */
 static bool knod_ipsec_poll_mode;
@@ -249,7 +249,7 @@ static bool knod_ipsec_poll_mode;
  * attaches. Hot-path code reads priv->nr_dispatchers which is
  * initialised from priv->knod->queue_cnt.
  *
- * Load-time only (0444) — flipping between 1 and N at runtime would
+ * Load-time only (0444) - flipping between 1 and N at runtime would
  * require tearing down / re-creating the knod context, which means
  * unbinding NOD on the NIC. Reload the module instead.
  */
@@ -316,7 +316,7 @@ knod_ipsec_lookup_slot_by_spi(struct knod_ipsec_priv *priv, u32 spi)
 
 /*
  * Write (or clear) a slot entry into the GPU-visible SA table via the
- * kernel mapping. SDMA flush is not required — the VRAM mapping used
+ * kernel mapping. SDMA flush is not required - the VRAM mapping used
  * here is coherent and the shader re-reads per-dispatch.
  */
 static void knod_ipsec_write_sa_entry(struct knod_ipsec_priv *priv,
@@ -347,7 +347,7 @@ static void knod_ipsec_write_sa_entry(struct knod_ipsec_priv *priv,
 	/* Store SPI in host byte order (little-endian on this platform).
 	 * The GPU shader byteswaps the raw BE SPI from the packet header
 	 * before comparing, so the table entry must be in the same
-	 * host-order form. cpu_to_le32(be32_to_cpu()) converts BE→host→LE
+	 * host-order form. cpu_to_le32(be32_to_cpu()) converts BE->host->LE
 	 * which on LE is a no-op for the numeric value.
 	 */
 	e->spi              = cpu_to_le32(be32_to_cpu(x->id.spi));
@@ -375,7 +375,7 @@ static void knod_ipsec_write_sa_entry(struct knod_ipsec_priv *priv,
 			key_len -= 4;
 		}
 		e->key_len = cpu_to_le32(key_len);
-		/* nr_rounds: AES-128→10, AES-192→12, AES-256→14 */
+		/* nr_rounds: AES-128->10, AES-192->12, AES-256->14 */
 		e->nr_rounds = cpu_to_le32(6 + key_len / 4);
 	}
 
@@ -486,7 +486,7 @@ static int knod_ipsec_xdo_state_add(struct knod_dev *knodev,
 		NL_SET_ERR_MSG(extack, "knod_ipsec: AES key expand failed");
 		goto err_key;
 	}
-	/* Store the encryption schedule. Nr+1 round keys × 16 bytes.
+	/* Store the encryption schedule. Nr+1 round keys x 16 bytes.
 	 * The shader reads s[SR_NR_ROUNDS] to know how many rounds.
 	 */
 	memcpy(slot->key_mem->kaddr, aes_ctx.key_enc,
@@ -694,7 +694,7 @@ static void knod_ipsec_xdo_state_update_stats(struct knod_dev *knodev,
  *
  * Caller guarantees that RSS pins the SA to a single RX queue, so the
  * only writer to `win` on this CPU is the NAPI for this queue. The
- * function both tests and updates — NIC dd calls it exactly once per
+ * function both tests and updates - NIC dd calls it exactly once per
  * desc, either to accept or to drop.
  */
 static inline bool knod_ipsec_sa_window_check(struct knod_ipsec_sa_window *win,
@@ -787,7 +787,7 @@ static void knod_ipsec_rxq_exit_all(struct knod_ipsec_priv *priv)
 }
 
 /* ========================================================================
- * NOD init / exit — allocate SA table and shared T-tables
+ * NOD init / exit - allocate SA table and shared T-tables
  * ========================================================================
  */
 
@@ -805,13 +805,13 @@ static int knod_ipsec_nod_init(struct knod_dev *knodev)
 	/*
 	 * Pin the module while IPsec is the selected feature: the core calls
 	 * into these ops, so it must not be unloaded until feature->none.
-	 * (No-op when built in — THIS_MODULE is NULL.)
+	 * (No-op when built in - THIS_MODULE is NULL.)
 	 */
 	if (!try_module_get(THIS_MODULE))
 		return -ENODEV;
 
 	/* kvzalloc because priv has grown large (slots[NR_SA] each with
-	 * win[KNOD_SPSC_MAX] sliding windows — a couple of MB now). kzalloc
+	 * win[KNOD_SPSC_MAX] sliding windows - a couple of MB now). kzalloc
 	 * may succeed but kvzalloc falls back to vmalloc if kmalloc can't
 	 * find contiguous pages, which is safer under memory pressure.
 	 */
@@ -1154,7 +1154,7 @@ static void knod_ipsec_nod_stop(struct knod_dev *knodev)
  * packet lives in VRAM; the CPU finish worker SDMA-copies it into a
  * per-queue delivery-pool page and publishes a knod_pass_desc onto the
  * framework pass_pending ring. Anti-replay and skb build happen in the NIC
- * dd NAPI consumer — the shader does neither. See knod_ipsec.h for the
+ * dd NAPI consumer - the shader does neither. See knod_ipsec.h for the
  * full data-flow description.
  */
 
@@ -1170,8 +1170,8 @@ static int knod_ipsec_init_shader_gfx9(struct knod *knod)
 	kd->kernel_code_entry_byte_offset = 1024;
 	kd->group_segment_fixed_size = KNOD_GCM_T_TABLES_TOTAL;
 
-	/* VGPRs: (gran+1)*4. Need v0-v42 (43 VGPRs) → gran=12 → 52.
-	 * SGPRs: (gran+1)*8. Need s0-s59 (SR_RK2) → gran=7 → 64.
+	/* VGPRs: (gran+1)*4. Need v0-v42 (43 VGPRs) -> gran=12 -> 52.
+	 * SGPRs: (gran+1)*8. Need s0-s59 (SR_RK2) -> gran=7 -> 64.
 	 */
 	rsrc1.granulated_workitem_vgpr_count = 12;
 	rsrc1.granulated_wavefront_sgpr_count = 7;
@@ -1224,7 +1224,7 @@ static int knod_ipsec_init_shader_gfx10(struct knod *knod)
 	/* VGPRs: Wave64, granularity=4. (12+1)*4 = 52 VGPRs.
 	 * Shader uses v0-v42 (VR_SAVE_ESP_OFF).
 	 *
-	 * SGPRs: RDNA2 ignores granulated_wavefront_sgpr_count —
+	 * SGPRs: RDNA2 ignores granulated_wavefront_sgpr_count -
 	 * SGPRs come from a flat 106-entry pool. Field is reserved
 	 * and must be 0 (non-zero corrupts RSRC1 interpretation on
 	 * some RDNA2 steppings, causing SQC inst-fetch faults).
@@ -1299,7 +1299,7 @@ static void knod_ipsec_fill_dispatch(struct knod *knod,
 /*
  * Prepare the dispatcher's single work slot to run the fused RX shader
  * over `sub[0..nr)`. Must be called from dispatcher context only (or while
- * the dispatcher is parked — e.g. from KAT). `bds` may be NULL for the
+ * the dispatcher is parked - e.g. from KAT). `bds` may be NULL for the
  * in-kernel KAT path; in that case the KAT owns out_addr and this helper
  * leaves it untouched.
  */
@@ -1368,7 +1368,7 @@ static void knod_ipsec_prepare_rx_dispatch(struct knod_ipsec_priv *priv,
 /*
  * Legacy exported entry points. With the single-dispatcher architecture,
  * NICs publish bds into knodev->wpriv[].spsc_bds and the dispatcher polls
- * them directly — no NIC driver actually calls these anymore, but keep the
+ * them directly - no NIC driver actually calls these anymore, but keep the
  * exports so external out-of-tree builds don't break while they transition.
  */
 int knod_ipsec_rx_submit(struct knod_ipsec_fused_sub *sub, int nr,
@@ -1387,7 +1387,7 @@ int knod_ipsec_rx_submit_bds(struct knod_ipsec_fused_sub *sub,
 EXPORT_SYMBOL_GPL(knod_ipsec_rx_submit_bds);
 
 /*
- * Shader verdict sentinels (low-side) — kept in lockstep with
+ * Shader verdict sentinels (low-side) - kept in lockstep with
  * ipsec_fused_gfx9.h. `bd->act` is packed as (low32=snapshot, high32=
  * slot_idx|sentinel); we only read the high half here.
  */
@@ -1455,7 +1455,7 @@ static void knod_ipsec_finish_rx_deliver(struct knod_ipsec_dispatcher *disp,
 
 	/* Step 1: classify + schedule SDMA for hits. Each packet in the
 	 * batch may belong to a different NIC RX queue, so rxq routing
-	 * happens per-packet via work->rx_pkt_queue[i] → priv->rxq[].
+	 * happens per-packet via work->rx_pkt_queue[i] -> priv->rxq[].
 	 */
 	for (i = 0; i < work->nr_packets; i++) {
 		struct knod_ipsec_sa_slot *sa_slot;
@@ -1752,7 +1752,7 @@ static void knod_ipsec_finish_rx_complete(struct knod_ipsec_dispatcher *disp,
  *
  * Ordering w.r.t. the bd recycle ring: the NIC driver should drain its
  * bd ring *first* (to recycle netmem back into the page_pool) and then
- * call drain_rx. The two rings are independent — bd ring delivers no
+ * call drain_rx. The two rings are independent - bd ring delivers no
  * verdicts, desc ring carries only PASS candidates.
  */
 /*
@@ -1934,7 +1934,7 @@ static void knod_ipsec_finalise_work(struct knod_ipsec_dispatcher *disp,
 		       sizeof(work->rx_bds[0]) * work->nr_packets);
 
 	/* Timing stats are now accumulated by the dispatcher
-	 * (try_rx) which has visibility into all phases —
+	 * (try_rx) which has visibility into all phases -
 	 * build / gpu / sdma / finalise. This function no longer
 	 * touches *_gpu_ns.
 	 */
@@ -1943,7 +1943,7 @@ static void knod_ipsec_finalise_work(struct knod_ipsec_dispatcher *disp,
 /*
  * Kick the GPU using kaql[disp->kaql_idx]. Assigns a forward-looking
  * sigval by decrementing disp->dispatch_sigval_next so each in-flight
- * slot has a distinct target — required for depth-N pipelining where
+ * slot has a distinct target - required for depth-N pipelining where
  * multiple dispatches are queued on the same AQL queue and GPU
  * decrements signal->value by 1 per completion.
  *
@@ -2029,7 +2029,7 @@ static void knod_ipsec_dispatch_and_wait(struct knod_ipsec_dispatcher *disp,
  * priv->rxq[q] delivery pool + desc_ring.
  *
  * NAPIs for every queue we touched are scheduled at the end so the
- * driver-side act_handler sees the INFLIGHT → PASS/DROP transition and
+ * driver-side act_handler sees the INFLIGHT -> PASS/DROP transition and
  * recycles the netmem pages.
  */
 static bool knod_ipsec_dispatcher_try_rx(struct knod_ipsec_dispatcher *disp,
@@ -2103,7 +2103,7 @@ static bool knod_ipsec_dispatcher_try_rx(struct knod_ipsec_dispatcher *disp,
 
 	/* Build fused_param directly into kernarg. Zero the entire struct
 	 * so stale sub[batch_n..BATCH-1] entries from previous dispatches
-	 * cannot be picked up by a GPU kernarg prefetch — the GFX9 CP may
+	 * cannot be picked up by a GPU kernarg prefetch - the GFX9 CP may
 	 * speculatively read beyond grid_size_y into the kernarg buffer,
 	 * and a stale sub[].pkt_addr pointing at valid VRAM could cause
 	 * the shader to process garbage packets (observed as ICV failures
@@ -2306,7 +2306,7 @@ static bool knod_ipsec_dispatcher_try_rx(struct knod_ipsec_dispatcher *disp,
  * SDMA, completes everything inline and returns true so the
  * caller can transition directly to EMPTY.
  *
- * Returns true if fully done (→ EMPTY), false if → SDMA_PENDING.
+ * Returns true if fully done (-> EMPTY), false if -> SDMA_PENDING.
  */
 static bool knod_ipsec_finalise_inflight(struct knod_ipsec_dispatcher *disp,
 					 struct knod_ipsec_work *work)
@@ -2323,7 +2323,7 @@ static bool knod_ipsec_finalise_inflight(struct knod_ipsec_dispatcher *disp,
 	work->t_finalise_start = t_gpu_end;
 	knod_ipsec_finalise_work(disp, work);
 
-	/* RX path with SDMA copies pending — defer completion until the
+	/* RX path with SDMA copies pending - defer completion until the
 	 * SDMA fence fires. The dispatcher loop will poll sdma_fence_ptr
 	 * and call knod_ipsec_finalise_sdma_done().
 	 */
@@ -2341,10 +2341,10 @@ static bool knod_ipsec_finalise_inflight(struct knod_ipsec_dispatcher *disp,
 			if (work->rx_sdma_copies > s->rx_sdma_copies_max)
 				s->rx_sdma_copies_max = work->rx_sdma_copies;
 		}
-		return false;   /* → SDMA_PENDING */
+		return false;   /* -> SDMA_PENDING */
 	}
 
-	/* No SDMA copies — mark bds PASS and schedule NAPIs. */
+	/* No SDMA copies - mark bds PASS and schedule NAPIs. */
 	for (i = 0; i < work->nr_packets; i++) {
 		if (work->rx_bds[i])
 			work->rx_bds[i]->act = KNOD_IPSEC_PASS;
@@ -2387,7 +2387,7 @@ static bool knod_ipsec_finalise_inflight(struct knod_ipsec_dispatcher *disp,
 	work->rx_sdma_bytes = 0;
 	work->n_sdma_pending = 0;
 
-	return true;  /* → EMPTY */
+	return true;  /* -> EMPTY */
 }
 
 /*
@@ -2453,7 +2453,7 @@ static void knod_ipsec_finalise_sdma_done(struct knod_ipsec_dispatcher *disp,
  *      idle (usleep or cpu_relax spins).
  *
  * With nr_dispatchers > 1 the AQL queues run independently on the
- * GPU — disjoint CU allocations per kaql — so two dispatchers get
+ * GPU - disjoint CU allocations per kaql - so two dispatchers get
  * real parallel execution on the GPU. Within a single dispatcher,
  * kaql[i] is FIFO: dispatches complete in submission order, and each
  * slot's work->sigval is assigned a distinct target by
@@ -2595,7 +2595,7 @@ static void knod_ipsec_dispatcher_drain(struct knod_ipsec_dispatcher *disp)
 			knod_ipsec_dispatch_wait(disp, w);
 			if (!knod_ipsec_finalise_inflight(disp, w)) {
 				/*
-				 * SDMA started — spin-wait, we can't
+				 * SDMA started - spin-wait, we can't
 				 * defer.
 				 */
 				knod_ipsec_fence_wait(w);
@@ -2615,7 +2615,7 @@ static void knod_ipsec_dispatcher_drain(struct knod_ipsec_dispatcher *disp)
  *
  * `work_pool[0..KNOD_IPSEC_NR_WORK-1]` are pipelined work slots owned by
  * the dispatcher kthread. Each slot gets its own slice of the param /
- * decrypt pool BOs — single large BOs avoid the multi-BO GPU-VA
+ * decrypt pool BOs - single large BOs avoid the multi-BO GPU-VA
  * mapping bug. KAT / selftest code paths always run against slot 0.
  *
  */
@@ -2673,7 +2673,7 @@ static int knod_ipsec_work_pool_alloc(struct knod_ipsec_priv *priv)
 		}
 
 		/* +KNOD_IPSEC_GTT_OUT_L3_OFF: 20 B headroom so the
-		 * shader's "L3 header → out_addr - L3_OFF" write has a
+		 * shader's "L3 header -> out_addr - L3_OFF" write has a
 		 * valid GPU VM target when a SLOT_NONE fallback directs
 		 * output here. Each work slot's rx_out_gaddr includes
 		 * this offset.
@@ -2750,7 +2750,7 @@ static void knod_ipsec_work_pool_free(struct knod_ipsec_priv *priv)
  *
  * Two-layer validation:
  *
- *   1) CPU layer — randomized H-table check
+ *   1) CPU layer - randomized H-table check
  *      For each supported AES key length (128/192/256), run N iterations:
  *      generate a fresh random key, compute the reference H = AES_K(0^128)
  *      via the kernel's verified <crypto/aes.h> library, then recompute the
@@ -2759,7 +2759,7 @@ static void knod_ipsec_work_pool_free(struct knod_ipsec_priv *priv)
  *      aes_encrypt for every round count and the downstream gf128 squaring
  *      chain that builds the H-power table. No hand-computed constants.
  *
- *   2) GPU layer — multi-packet shader dispatch smoke test
+ *   2) GPU layer - multi-packet shader dispatch smoke test
  *      Run the fused RX shader at several batch sizes (1, 8, 32, 64) with
  *      each sub[i].bd_addr pointing at a distinct fake spsc_bd slot inside
  *      a single scratch BO. Pre-stamp each bd->act with a UNIQUE sentinel
@@ -2846,16 +2846,16 @@ static int knod_ipsec_run_cpu_kat(void)
  * slot_idx (as u64) into bd->act.
  *
  * Verification scope (single pass):
- *   - even i (IPv4): bd->act high32 == 0xFFFFFFFD (ICV fail — garbage
+ *   - even i (IPv4): bd->act high32 == 0xFFFFFFFD (ICV fail - garbage
  *     keys mean decryption produces wrong tag, but the full crypto
  *     pipeline runs to completion proving SPI scan + dispatch work)
- *   - odd  i (IPv6): bd->act high32 == 0xFFFFFFFD (ICV fail — same as
+ *   - odd  i (IPv6): bd->act high32 == 0xFFFFFFFD (ICV fail - same as
  *     IPv4 but exercises the IPv6 ESP offset path; SPI at +54)
  *
  * The 32d.1/32d.2 in-shader replay bitmap path has been removed (the
  * sliding window now lives CPU-side in the NIC dd NAPI), so the
  * second dispatch pass and the replay_bitmap_addr/readback block have
- * been dropped. End-to-end worker→desc_ring→NIC-dd delivery is covered
+ * been dropped. End-to-end worker->desc_ring->NIC-dd delivery is covered
  * by the userspace selftest `knod_ipsec_offload.sh`, not by this KAT.
  */
 static int knod_ipsec_run_shader_kat_n(struct knod_ipsec_priv *priv, int nr)
@@ -2865,7 +2865,7 @@ static int knod_ipsec_run_shader_kat_n(struct knod_ipsec_priv *priv, int nr)
 	const size_t SLOT_STRIDE = 64;
 	/* must fit IPv6 ESP minimum (86B overhead) */
 	const size_t PKT_STRIDE  = 128;
-	/* Heap-backed sub[] — at BATCH=512 the stack copy would be 16 KB
+	/* Heap-backed sub[] - at BATCH=512 the stack copy would be 16 KB
 	 * and overflow the dispatcher kernel stack. KAT is cold path, so
 	 * kvmalloc is fine.
 	 */
@@ -2902,7 +2902,7 @@ static int knod_ipsec_run_shader_kat_n(struct knod_ipsec_priv *priv, int nr)
 		goto out_free;
 	}
 
-	/* Reuse the persistent per-priv scratch BO — see priv->kat_scratch */
+	/* Reuse the persistent per-priv scratch BO - see priv->kat_scratch */
 	scratch = priv->kat_scratch;
 	if (!scratch) {
 		scnprintf(knod_ipsec_last_kat_detail,
@@ -2918,7 +2918,7 @@ static int knod_ipsec_run_shader_kat_n(struct knod_ipsec_priv *priv, int nr)
 	 * fixtures. Without this, any production SA installed by the user
 	 * (e.g. via `ip xfrm state add`) gets wiped when the KAT wipes the
 	 * SA BO at exit, which causes a subsequent production dispatch
-	 * to load key_gpu_addr=0 → VM fault at address 0.
+	 * to load key_gpu_addr=0 -> VM fault at address 0.
 	 */
 	sa_backup = kvmalloc(KNOD_IPSEC_SA_BO_SIZE, GFP_KERNEL);
 	if (!sa_backup) {
@@ -2981,8 +2981,8 @@ static int knod_ipsec_run_shader_kat_n(struct knod_ipsec_priv *priv, int nr)
 
 		/* Alternate IPv4 / IPv6 packets per slot to exercise both
 		 * code paths in the same batch. Even i: standard IPv4 header
-		 * (version=4, IHL=5 → byte 0x45), SPI at offset 34.
-		 * Odd i: IPv6 header (version=6 → byte 0x60), SPI at
+		 * (version=4, IHL=5 -> byte 0x45), SPI at offset 34.
+		 * Odd i: IPv6 header (version=6 -> byte 0x60), SPI at
 		 * offset 54. Both hit the SA scan, both get ICV fail
 		 * (since ciphertext is garbage).
 		 */
@@ -3004,7 +3004,7 @@ static int knod_ipsec_run_shader_kat_n(struct knod_ipsec_priv *priv, int nr)
 
 	/* Single dispatch: post-32d.2 architecture has no in-shader replay,
 	 * so the KAT only validates the fresh scan-hit path (+ the IPv6
-	 * IPv6 ESP offset path). End-to-end worker→desc_ring→NAPI delivery
+	 * IPv6 ESP offset path). End-to-end worker->desc_ring->NAPI delivery
 	 * is covered by the userspace selftest, not here.
 	 */
 	/* Force the dispatch onto queue 0 so the signal we observe below is
@@ -3042,8 +3042,8 @@ static int knod_ipsec_run_shader_kat_n(struct knod_ipsec_priv *priv, int nr)
 	/* bd->act is packed as
 	 *    low  = s22 = scan target SPI
 	 *    high = s26 = final result
-	 *      even i (IPv4): ICV fail → 0xFFFFFFFD
-	 *      odd  i (IPv6): ICV fail → 0xFFFFFFFD
+	 *      even i (IPv4): ICV fail -> 0xFFFFFFFD
+	 *      odd  i (IPv6): ICV fail -> 0xFFFFFFFD
 	 *      scan miss    : 0xFFFFFFFF
 	 *
 	 * Both IPv4 and IPv6 paths run the full crypto pipeline. The SPI
@@ -3052,8 +3052,8 @@ static int knod_ipsec_run_shader_kat_n(struct knod_ipsec_priv *priv, int nr)
 	 */
 	written_final = 0;
 #define KAT_EXPECT_LOW_MASK  (0ULL)
-/* Both IPv4 and IPv6 slots: full crypto pipeline → ICV mismatch
- * → verdict = VERDICT_ICV_FAIL (0xFFFFFFFD).
+/* Both IPv4 and IPv6 slots: full crypto pipeline -> ICV mismatch
+ * -> verdict = VERDICT_ICV_FAIL (0xFFFFFFFD).
  */
 #define KAT_EXPECT_FOR_SLOT						\
 	(((u64)KNOD_IPSEC_SHADER_VERDICT_ICV_FAIL << 32) | 0ULL)
@@ -3132,7 +3132,7 @@ static int knod_ipsec_run_shader_kat_n(struct knod_ipsec_priv *priv, int nr)
 		nr, nr, tries * 750);
 
 out_free:
-	/* Restore the production SA table we saved at entry. Never wipe —
+	/* Restore the production SA table we saved at entry. Never wipe -
 	 * wiping would destroy any live xfrm SAs installed by userspace.
 	 */
 	if (sa_backup) {
@@ -3163,7 +3163,7 @@ out_free:
  * ========================================================================
  */
 
-/* GF(2^128) multiply for reference GHASH — identical to gcm_core but
+/* GF(2^128) multiply for reference GHASH - identical to gcm_core but
  * local to avoid exporting an internal helper for test-only use.
  */
 static void kat_gf128_mul(u64 r[2], const u64 a[2], const u64 b[2])
@@ -3311,7 +3311,7 @@ static int knod_ipsec_run_crypto_kat(struct knod_ipsec_priv *priv)
 			  "crypto-kat FAIL: aes_expandkey=%d", ret);
 		return ret;
 	}
-	/* AES-128: 11 round keys × 4 u32 = 44 u32 = 176B */
+	/* AES-128: 11 round keys x 4 u32 = 44 u32 = 176B */
 	memcpy(key_buf, aes_ctx.key_enc,
 	       (aes_ctx.key_length / 4 + 7) * 16);
 	/* Also prepare aes_enckey for CPU-side reference encryption */
@@ -3753,7 +3753,7 @@ static int knod_ipsec_stats_show(struct seq_file *s, void *v)
 	seq_printf(s, "drain_zc_ok    : %llu\n", tot.drain_zc_ok);
 	seq_printf(s, "drain_zc_fallback: %llu\n", tot.drain_zc_fallback);
 
-	/* Per-queue SPSC ring state — shows where bds are stuck */
+	/* Per-queue SPSC ring state - shows where bds are stuck */
 	if (priv && priv->knodev) {
 		int nr_q = priv->knodev->netdev ?
 			priv->knodev->netdev->real_num_rx_queues : 0;
@@ -4172,7 +4172,7 @@ static void knod_ipsec_debugfs_exit(struct knod_ipsec_priv *priv)
 }
 
 /* ========================================================================
- * Policy offload — accept PACKET-mode policies so xfrm_state_find()
+ * Policy offload - accept PACKET-mode policies so xfrm_state_find()
  * will match our PACKET-mode SAs. No GPU-side action needed; we just
  * return 0 to let the kernel record the offload type on the policy.
  * ========================================================================

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_ipsec.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_ipsec.h
@@ -41,14 +41,14 @@ struct knod_ipsec_priv;
 
 /*
  * CPU-side per-queue sliding anti-replay window (knod_ipsec_sa_window).
- * Independent from the GPU-side REPLAY_BITS above — the shader's
+ * Independent from the GPU-side REPLAY_BITS above - the shader's
  * replay region stays 128 bits for GPU-visible state, but the CPU path
  * needs a much larger window because with multi-queue RSS the packets
  * of a single SA may land on several RX queues due to NIC hash
  * collisions. Each per-queue window then sees only a sparse subset of
  * the SA's monotonic seq stream, and the seq gap between consecutive
  * packets arriving at one queue can exceed 128 easily. 2048 bits lets
- * the window absorb worst-case gaps (e.g. 8 queues × 256 batch).
+ * the window absorb worst-case gaps (e.g. 8 queues x 256 batch).
  *
  * Sized as u64 words for easier bit-shift logic in the check function.
  */
@@ -158,7 +158,7 @@ struct knod_ipsec_sa_gpu_stats {
 	 KNOD_IPSEC_STATS_REGION_SIZE)
 
 /*
- * RFC 4303 anti-replay sliding window — CPU-side, per-SA, per-RXQ.
+ * RFC 4303 anti-replay sliding window - CPU-side, per-SA, per-RXQ.
  *
  * RSS hashes ESP flows on (saddr, daddr, proto, SPI) so that every packet
  * of a given SA lands on the same NIC RX queue. That means a single writer
@@ -184,7 +184,7 @@ struct knod_ipsec_sa_slot {
 	u32 version;
 	bool active;
 	/* Per-RXQ sliding window state. Owned by the NIC dd NAPI for that
-	 * queue — do not touch from control plane while SA is active.
+	 * queue - do not touch from control plane while SA is active.
 	 */
 	struct knod_ipsec_sa_window win[KNOD_SPSC_MAX];
 };
@@ -250,7 +250,7 @@ struct knod_ipsec_stats {
 	 * processes `drain_found` descriptors; these buckets split the
 	 * CPU work per-phase so we can see which step dominates:
 	 *   drain_alloc_ns  : knod_pass_build_skb cost
-	 *   drain_copy_ns   : legacy copy cost (0 — delivery is zero-copy)
+	 *   drain_copy_ns   : legacy copy cost (0 - delivery is zero-copy)
 	 *   drain_proto_ns  : L3 header patch + secpath setup
 	 *   drain_gro_ns    : netif_receive_skb_list (stack entry)
 	 *   drain_total_ns  : end-to-end drain_rx call time
@@ -273,18 +273,18 @@ struct knod_ipsec_stats {
  * in-flight dispatches are queued in-order and complete in-order.
  *
  * A slot's lifecycle:
- *   EMPTY          → try_tx/try_rx fills kernarg and submits → INFLIGHT
- *   INFLIGHT       → GPU running; dispatcher polls completion signal
- *   INFLIGHT       → signal fires → start SDMA copies + fence (no spin)
- *                    → SDMA_PENDING
- *   SDMA_PENDING   → dispatcher polls SDMA fence (non-blocking)
- *   SDMA_PENDING   → fence done → desc publish, napi kicks, bd PASS,
- *                    stats → EMPTY
+ *   EMPTY          -> try_tx/try_rx fills kernarg and submits -> INFLIGHT
+ *   INFLIGHT       -> GPU running; dispatcher polls completion signal
+ *   INFLIGHT       -> signal fires -> start SDMA copies + fence (no spin)
+ *                    -> SDMA_PENDING
+ *   SDMA_PENDING   -> dispatcher polls SDMA fence (non-blocking)
+ *   SDMA_PENDING   -> fence done -> desc publish, napi kicks, bd PASS,
+ *                    stats -> EMPTY
  *
  * The SDMA_PENDING state decouples the SDMA fence wait from the
  * dispatcher loop so the CPU never busy-spins on the fence. While
  * one slot sits in SDMA_PENDING, the dispatcher can build and
- * submit the next batch into another EMPTY slot — true 3-way
+ * submit the next batch into another EMPTY slot - true 3-way
  * parallelism of GPU execution, SDMA transfer, and CPU build.
  */
 #define KNOD_IPSEC_NR_WORK		4
@@ -314,9 +314,9 @@ struct knod_ipsec_stats {
 	ALIGN(sizeof(struct knod_ipsec_fused_param), 64)
 
 struct knod_ipsec_sdma_ctl {
-	/*  0: atomic — SDMA-needing WGs increment */
+	/*  0: atomic - SDMA-needing WGs increment */
 	__le32	claim_counter;
-	__le32	done_counter;		/*  4: atomic — ALL WGs increment */
+	__le32	done_counter;		/*  4: atomic - ALL WGs increment */
 	/*  8: current wptr byte offset (CPU snapshot) */
 	__le64	wptr_val;
 	__le64	fence_addr;		/* 16: SDMA fence write target GPU VA */
@@ -328,7 +328,7 @@ struct knod_ipsec_sdma_ctl {
 	__le32	nr_total_wg;		/* 36: grid_size_y = nr_packets */
 	__le32	copy_hdr;		/* 40: SDMA COPY_LINEAR header dword */
 	__le32	fence_hdr;		/* 44: SDMA FENCE header dword */
-	__le32	gpu_sdma_ready;		/* 48: last WG sets 1 → CPU polls */
+	__le32	gpu_sdma_ready;		/* 48: last WG sets 1 -> CPU polls */
 	/* 52: total SDMA COPY packets emitted */
 	__le32	final_sdma_count;
 	/* 56: GPU VA of HW wptr (queue->gaddr+8) */
@@ -361,7 +361,7 @@ enum knod_ipsec_work_state {
  * BO owned by `struct knod_ipsec_works`, not individual BOs. Allocating
  * many small BOs and mapping them all to the KFD process GPU VA hits a
  * long-standing AMDKFD issue where only the first BO is reliably mapped
- * (see memory/gtt_multi_bo_bug.md) — subsequent BOs fault on GPU access.
+ * (see memory/gtt_multi_bo_bug.md) - subsequent BOs fault on GPU access.
  * One large pool BO, sliced at fixed offsets, sidesteps this entirely.
  */
 struct knod_ipsec_slice {
@@ -374,7 +374,7 @@ struct knod_ipsec_slice {
  * schedules SDMA copies, then read back to publish desc_ring entries.
  *
  * Kept as an array inside struct knod_ipsec_work so the dispatcher does
- * not have to stack-allocate BATCH * sizeof(...) on every finalise — at
+ * not have to stack-allocate BATCH * sizeof(...) on every finalise - at
  * large PKT_BATCH values (512+) stack allocation would overflow the
  * 16 KB kernel stack.
  */
@@ -416,7 +416,7 @@ struct knod_ipsec_work {
 	s64			sigval;
 	u64			dispatch_ts;
 	/* SDMA deferred-fence state. When the work transitions from
-	 * INFLIGHT → SDMA_PENDING, finish_rx_deliver queues copies +
+	 * INFLIGHT -> SDMA_PENDING, finish_rx_deliver queues copies +
 	 * fence but does NOT spin. The dispatcher checks sdma_fence_ptr
 	 * on the next iteration and transitions to EMPTY once the fence
 	 * fires. sdma_fence_target is the expected fence value; the
@@ -439,7 +439,7 @@ struct knod_ipsec_work {
 	u32			rx_sdma_bytes;
 	/* Deferred SDMA completion state. finish_rx_deliver stores
 	 * n_sdma_pending + pkt_idx_of[] so the dispatcher's
-	 * SDMA_PENDING → EMPTY transition can publish descs and mark
+	 * SDMA_PENDING -> EMPTY transition can publish descs and mark
 	 * bds without re-scanning the verdict loop.
 	 */
 	int			n_sdma_pending;
@@ -481,7 +481,7 @@ struct knod_ipsec_work {
 /*
  * Per-dispatcher runtime state. Each dispatcher kthread owns exactly
  * one of these and never shares hot-path state with any other
- * dispatcher — cursors, in-flight work slots, pool BOs, fence counters
+ * dispatcher - cursors, in-flight work slots, pool BOs, fence counters
  * and the kaql/sdma index are all private.
  *
  * Cross-dispatcher sharing lives in knod_ipsec_priv: the SA table +

--- a/drivers/net/ethernet/broadcom/bnxt/bnxt_xdp.c
+++ b/drivers/net/ethernet/broadcom/bnxt/bnxt_xdp.c
@@ -794,7 +794,6 @@ int bnxt_knod_init(struct bnxt *bp)
 
 void bnxt_knod_uninit(struct bnxt *bp)
 {
-	/* TODO detach first */
 	knod_netdev_unregister(bp->knetdev);
 	kfree(bp->knetdev);
 	bp->knetdev = NULL;

--- a/drivers/net/ethernet/mellanox/mlx5/core/en/xdp.c
+++ b/drivers/net/ethernet/mellanox/mlx5/core/en/xdp.c
@@ -1245,7 +1245,6 @@ int mlx5e_knod_init(struct mlx5e_priv *priv)
 
 void mlx5e_knod_uninit(struct mlx5e_priv *priv)
 {
-	/* TODO detach first */
 	knod_netdev_unregister(priv->knetdev);
 	kfree(priv->knetdev);
 	priv->knetdev = NULL;

--- a/include/net/knod.h
+++ b/include/net/knod.h
@@ -49,7 +49,7 @@ struct spsc_bd {
 #define KNOD_REDIRECT	XDP_REDIRECT	/* 4 */
 
 /*
- * Extended actions — accel-specific, must not collide with XDP range [0..7].
+ * Extended actions - accel-specific, must not collide with XDP range [0..7].
  * The NIC act_handler treats any unknown code as "in-flight to accel":
  * stop releasing at that entry and wait for the accel to update bd->act.
  */
@@ -459,7 +459,7 @@ void knod_ipsec_detach(struct knod_dev *knodev);
 #else
 #endif
 
-/* XDP PASS drain — called from NIC NAPI poll */
+/* XDP PASS drain - called from NIC NAPI poll */
 int knod_dev_xdp_drain_pass(struct knod_dev *knodev,
 				   struct napi_struct *napi,
 				   int queue_idx, int budget);

--- a/include/net/spsc_ring.h
+++ b/include/net/spsc_ring.h
@@ -6,11 +6,11 @@
  * contiguous page-backed memory pool.  Each slot is permanently bound
  * to a cacheline-aligned element inside that pool.
  *
- *   Producer calls spsc_produce() → receives a pointer to a free
+ *   Producer calls spsc_produce() -> receives a pointer to a free
  *   element, writes data into it, then calls spsc_produce_commit()
  *   to publish.
  *
- *   Consumer calls spsc_acquire() / spsc_pop() → receives a pointer
+ *   Consumer calls spsc_acquire() / spsc_pop() -> receives a pointer
  *   to a filled element.  After spsc_release() the slot becomes
  *   available to the producer again - the element pointer is reused
  *   automatically because it is fixed to the slot.
@@ -18,10 +18,10 @@
  * Two consumer modes (do NOT mix on the same instance):
  *
  *   Mode 1 - Sliding window (2-step consumer):
- *     spsc_produce / commit → peek → acquire → release
+ *     spsc_produce / commit -> peek -> acquire -> release
  *
  *   Mode 2 - Simple queue:
- *     spsc_push → pop
+ *     spsc_push -> pop
  *
  * Return convention:
  *   0           success
@@ -31,10 +31,10 @@
  *   -ENOMEM     allocation failure
  *
  * Memory ordering:
- *   Producer: write data → smp_store_release(head)
- *   Consumer: smp_load_acquire(head) → read data
- *   Consumer: done → smp_store_release(tail)
- *   Producer: smp_load_acquire(tail) → write data
+ *   Producer: write data -> smp_store_release(head)
+ *   Consumer: smp_load_acquire(head) -> read data
+ *   Consumer: done -> smp_store_release(tail)
+ *   Producer: smp_load_acquire(tail) -> write data
  *
  * Capacity is always a power of two.
  */
@@ -213,9 +213,9 @@ static inline unsigned int spsc_pending(const struct spsc_ring *r)
 /*  Producer API  (single thread only, shared by both modes)           */
 /*                                                                     */
 /*  Two-phase produce:                                                 */
-/*    1) spsc_produce()        → get pointer to free element           */
+/*    1) spsc_produce()        -> get pointer to free element           */
 /*    2) caller writes data                                            */
-/*    3) spsc_produce_commit() → publish to consumer                   */
+/*    3) spsc_produce_commit() -> publish to consumer                   */
 /*                                                                     */
 /*  Or one-shot: spsc_push() for pre-filled elements.                  */
 /* ================================================================== */
@@ -319,10 +319,10 @@ static inline void spsc_produce_commit_n(struct spsc_ring *r, unsigned int n)
 /* ================================================================== */
 /*  Mode 1: Sliding window consumer  (single thread only)              */
 /*                                                                     */
-/*    peek    → read from acquired cursor, no cursor movement          */
-/*    acquire → advance acquired cursor, return element pointers       */
-/*    release → advance tail, slots become reusable by producer        */
-/*    rewind  → reset acquired back to tail                            */
+/*    peek    -> read from acquired cursor, no cursor movement          */
+/*    acquire -> advance acquired cursor, return element pointers       */
+/*    release -> advance tail, slots become reusable by producer        */
+/*    rewind  -> reset acquired back to tail                            */
 /* ================================================================== */
 
 /**

--- a/net/knod/knod_core.c
+++ b/net/knod/knod_core.c
@@ -369,7 +369,7 @@ int knod_d2h_drain(struct knod_dev *knodev, int napi_index,
 EXPORT_SYMBOL(knod_d2h_drain);
 
 /* ======================================================================
- * NOD IPsec proxy — bridges standard kernel xfrmdev_ops to
+ * NOD IPsec proxy - bridges standard kernel xfrmdev_ops to
  * knod_accel_ipsec_ops on the GPU accelerator.
  * ======================================================================
  */

--- a/tools/testing/selftests/drivers/net/knod/knod_attach.sh
+++ b/tools/testing/selftests/drivers/net/knod/knod_attach.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # SPDX-License-Identifier: GPL-2.0
 #
-# knod_attach.sh — exercise the knod attach/detach control plane.
+# knod_attach.sh - exercise the knod attach/detach control plane.
 #
 # Checks the NIC<->accel binding lifecycle (attach makes the pair appear in the
 # xdev list, detach removes it) and that malformed or impossible attach
@@ -64,7 +64,7 @@ expect_reject() {
 	fi
 }
 
-# ── prereq ──────────────────────────────────────────────────────
+# -- prereq ------------------------------------------------------
 knod_check_prereq
 
 if [ -z "$NIC" ]; then
@@ -90,7 +90,7 @@ echo ""
 ip link set dev "$NIC" down 2>/dev/null
 knod_detach "$NIC" 2>/dev/null
 
-# ── positive lifecycle ────────────────────────────────────────
+# -- positive lifecycle ----------------------------------------
 knod_attach "$NIC" "$accel_id"
 check_result "attach $NIC -> accel $accel_id" $?
 
@@ -106,7 +106,7 @@ else
 	check_result "xdev drops $NIC after detach" 0
 fi
 
-# ── negative requests must be rejected ────────────────────────
+# -- negative requests must be rejected ------------------------
 nic_ifindex=$(knod_ifindex "$NIC")
 expect_reject "reject attach with no accel id"     "{\"nic-ifindex\":$nic_ifindex}"
 expect_reject "reject attach to nonexistent accel" "{\"nic-ifindex\":$nic_ifindex,\"accel-id\":999999}"
@@ -116,16 +116,16 @@ ip link set dev "$NIC" up 2>/dev/null
 expect_reject "reject attach while NIC is up"      "{\"nic-ifindex\":$nic_ifindex,\"accel-id\":$accel_id}"
 ip link set dev "$NIC" down 2>/dev/null
 
-# ── framework survived the bad requests ───────────────────────
+# -- framework survived the bad requests -----------------------
 knod_kernel_alive
 check_result "framework responsive after bad requests" $?
 
-# ── re-attach still works (state not corrupted) ───────────────
+# -- re-attach still works (state not corrupted) ---------------
 knod_attach "$NIC" "$accel_id"
 check_result "re-attach after errors" $?
 knod_detach "$NIC" 2>/dev/null
 
-# ── summary ──────────────────────────────────────────────────
+# -- summary --------------------------------------------------
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 

--- a/tools/testing/selftests/drivers/net/knod/knod_xdp_ktime.sh
+++ b/tools/testing/selftests/drivers/net/knod/knod_xdp_ktime.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # SPDX-License-Identifier: GPL-2.0
 #
-# knod_xdp_ktime.sh — test bpf_ktime_get_ns() on GPU XDP offload
+# knod_xdp_ktime.sh - test bpf_ktime_get_ns() on GPU XDP offload
 #
 # Loads an XDP program that calls bpf_ktime_get_ns() and stores
 # the result in an offloaded BPF_MAP_TYPE_ARRAY, then verifies
@@ -55,7 +55,7 @@ check_result() {
 	fi
 }
 
-# ── prereq ──────────────────────────────────────────────────────
+# -- prereq ------------------------------------------------------
 knod_check_prereq
 
 if [ -z "$NIC" ]; then
@@ -77,13 +77,13 @@ echo "    NIC:      $NIC"
 echo "    ACCEL_ID: $accel_id"
 echo ""
 
-# ── check BPF object ──────────────────────────────────────────
+# -- check BPF object ------------------------------------------
 if [ ! -f "$BPF_OBJ" ]; then
 	echo "FAIL: $BPF_OBJ not found (run make first)"
 	exit 1
 fi
 
-# ── attach NIC to GPU, select bpf feature ─────────────────────
+# -- attach NIC to GPU, select bpf feature ---------------------
 ip link set dev "$NIC" down 2>/dev/null
 knod_attach "$NIC" "$accel_id"
 if [ $? -ne 0 ]; then
@@ -96,14 +96,14 @@ if [ $? -ne 0 ]; then
 	knod_skip "cannot select bpf feature"
 fi
 
-# ── load XDP offload program ──────────────────────────────────
+# -- load XDP offload program ----------------------------------
 knod_xdp_load "$NIC" "$BPF_OBJ"
 if [ $? -ne 0 ]; then
 	echo "FAIL: xdpoffload load failed"
 	exit 1
 fi
 
-# ── find prog/map IDs ─────────────────────────────────────────
+# -- find prog/map IDs -----------------------------------------
 prog_id=$(bpftool prog show 2>/dev/null | \
 	  awk '/xdp_ktime_test/ {sub(/:/, "", $1); print $1; exit}')
 if [ -z "$prog_id" ]; then
@@ -119,7 +119,7 @@ if [ -z "$map_id" ]; then
 fi
 knod_log "map_id=$map_id"
 
-# ── bring up interface and generate traffic ───────────────────
+# -- bring up interface and generate traffic -------------------
 ip link set dev "$NIC" up
 
 if [ -n "$REMOTE_IP" ]; then
@@ -130,10 +130,10 @@ else
 	sleep 10
 fi
 
-# ── bring down interface before reading map ──────────────────
+# -- bring down interface before reading map ------------------
 ip link set dev "$NIC" down
 
-# ── read map and verify ──────────────────────────────────────
+# -- read map and verify --------------------------------------
 ktime_val=$(knod_map_lookup_u64 "$map_id" 0)
 pkt_count=$(knod_map_lookup_u64 "$map_id" 1)
 
@@ -163,7 +163,7 @@ if [ "$ktime_val" -gt 0 ]; then
 	fi
 fi
 
-# ── summary ──────────────────────────────────────────────────
+# -- summary --------------------------------------------------
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 

--- a/tools/testing/selftests/drivers/net/knod/knod_xdp_loop.sh
+++ b/tools/testing/selftests/drivers/net/knod/knod_xdp_loop.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # SPDX-License-Identifier: GPL-2.0
 #
-# knod_xdp_loop.sh — the KNOD JIT must reject a bounded-loop XDP program.
+# knod_xdp_loop.sh - the KNOD JIT must reject a bounded-loop XDP program.
 #
 # Loop emission is not implemented yet, so a program with a real back-edge has
 # to be rejected with -EOPNOTSUPP at JIT time rather than miscompiled.  This
@@ -53,7 +53,7 @@ check_result() {
 	fi
 }
 
-# ── prereq ──────────────────────────────────────────────────────
+# -- prereq ------------------------------------------------------
 knod_check_prereq
 
 if [ -z "$NIC" ]; then
@@ -80,7 +80,7 @@ echo "    NIC:      $NIC"
 echo "    ACCEL_ID: $accel_id"
 echo ""
 
-# ── setup: attach NIC to GPU, then select the bpf feature ─────
+# -- setup: attach NIC to GPU, then select the bpf feature -----
 # feature_select needs the accel already attached (it swaps the live
 # worker), so attach first.
 ip link set dev "$NIC" down 2>/dev/null
@@ -98,10 +98,10 @@ fi
 # remember where dmesg is now so we only scan messages from this load
 dmesg_mark=$(dmesg | wc -l)
 
-# ── load must fail ────────────────────────────────────────────
+# -- load must fail --------------------------------------------
 knod_log "loading bounded-loop program (expecting rejection)"
 if knod_xdp_load "$NIC" "$BPF_OBJ" 2>/dev/null; then
-	# unexpectedly accepted — unload and fail
+	# unexpectedly accepted - unload and fail
 	knod_xdp_unload "$NIC"
 	check_result "loop program rejected at load" 1
 else
@@ -110,16 +110,16 @@ fi
 
 new_dmesg=$(dmesg | tail -n +"$((dmesg_mark + 1))")
 
-# ── back-edge reported ────────────────────────────────────────
+# -- back-edge reported ----------------------------------------
 rc=1
 echo "$new_dmesg" | grep -q "knod_loop:.*back-edge" && rc=0
 check_result "loop back-edge reported in dmesg" $rc
 
-# ── framework still alive ─────────────────────────────────────
+# -- framework still alive -------------------------------------
 knod_kernel_alive
 check_result "system responsive after rejection" $?
 
-# ── summary ──────────────────────────────────────────────────
+# -- summary --------------------------------------------------
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 

--- a/tools/testing/selftests/drivers/net/knod/lib.sh
+++ b/tools/testing/selftests/drivers/net/knod/lib.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # SPDX-License-Identifier: GPL-2.0
 #
-# lib.sh — KNOD XDP offload test utilities
+# lib.sh - KNOD XDP offload test utilities
 #
 # The KNOD control plane is the "knod" generic-netlink family; it is driven
 # here through the in-tree ynl CLI (tools/net/ynl/pyynl/cli.py) so the tests

--- a/tools/testing/selftests/drivers/net/knod/xdp_loop.bpf.c
+++ b/tools/testing/selftests/drivers/net/knod/xdp_loop.bpf.c
@@ -7,7 +7,7 @@
  *
  * The trip count is read from the packet (runtime) and unrolling is disabled,
  * so the compiler keeps a real loop with a back-edge instead of folding it
- * into straight-line code.  The body is an xorshift step — a non-affine
+ * into straight-line code.  The body is an xorshift step - a non-affine
  * recurrence the compiler cannot reduce to a closed form (a simple sum like
  * "sum += i" gets turned into n*(n-1)/2 and the loop disappears).  It touches
  * no memory inside the loop, so the verifier is happy, and it has the simplest


### PR DESCRIPTION
Carries the source cleanups from the RFC series (`knod-rfc-clean`) back into
the development branch, so regenerating the RFC series becomes a plain rebase
instead of a re-cleanup.

- `WARN_ON(1)` -> `WARN_ON_ONCE(1)` in the emitter and BPF JIT (157 sites).
  These sit in per-instruction emit loops, so one bad program splats once per
  emitted instruction.
- Drop five stale TODO comments; reword the ipsec disassembler's
  empty-shader note. Debug scaffolding untouched.
- Non-ASCII -> ASCII in comments, `pr_*()` strings and selftest banners
  (checkpatch `UTF8_BEFORE_PATCH`; box-drawing breaks under a non-UTF-8 locale).

The result is identical to `knod-rfc-clean` except for `CFLAGS_ovs_packet`,
which comes from the dev-only ynl patch at the base of `knod-7.2` and stays
here on purpose.

No functional change: with comments and string literals stripped, the only
code difference between the branches is the 157 `WARN_ON` conversions.

Builds. checkpatch is clean (3 `PREFER_FALLTHROUGH` warnings on pre-existing
context lines). The `-Wunused-variable` warnings in `ipsec_fused_gfx10.h` are
pre-existing — those variables are only read inside the `KNOD_IPSEC_GFX10_DIAG_STUB`
blocks, which are off by default.