### PR TITLE
drm/amdkfd: knod: fix shader end padding and the packet cache bound

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/knod/ipsec_bench_gfx11.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/ipsec_bench_gfx11.h
@@ -182,7 +182,7 @@ static int knod_gfx11_bench_ctext_addr(u32 *buf, int n, int blk_vgpr)
 static inline int kfd_ipsec_gen_base_bench_shader_gfx11(void *vbuf)
 {
 	u32 *buf = (u32 *)vbuf;
-	int n = 0;
+	int pad, n = 0;
 
 	n = knod_gfx11_bench_prologue(buf, n);
 
@@ -195,7 +195,7 @@ static inline int kfd_ipsec_gen_base_bench_shader_gfx11(void *vbuf)
 	   P_V(VR_S0), 0);
 	_E(emit_gfx11_s_waitcnt_vmcnt, I11(buf, n));
 	_E(emit_gfx11_s_endpgm, I11(buf, n));
-	while (n % 256)
+	for (pad = 0; pad < KNOD_IPSEC_SHADER_PAD_DWORDS; pad++)
 		_E(emit_gfx11_s_code_end, I11(buf, n));
 
 	return n * 4;
@@ -209,7 +209,7 @@ static inline int kfd_ipsec_gen_ctr_bench_shader_gfx11(void *vbuf)
 {
 	u32 *buf = (u32 *)vbuf;
 	int br_execz;
-	int n = 0;
+	int pad, n = 0;
 
 	n = knod_gfx11_bench_prologue(buf, n);
 
@@ -275,7 +275,7 @@ static inline int kfd_ipsec_gen_ctr_bench_shader_gfx11(void *vbuf)
 	_E(emit_gfx11_s_mov_b64, I11(buf, n), 126 /* EXEC */, SR_EXEC_SAVE);
 	_E(emit_gfx11_s_waitcnt_vmcnt, I11(buf, n));
 	_E(emit_gfx11_s_endpgm, I11(buf, n));
-	while (n % 256)
+	for (pad = 0; pad < KNOD_IPSEC_SHADER_PAD_DWORDS; pad++)
 		_E(emit_gfx11_s_code_end, I11(buf, n));
 
 	return n * 4;
@@ -295,7 +295,7 @@ static inline int kfd_ipsec_gen_ghash_bench_shader_gfx11(void *vbuf)
 {
 	u32 *buf = (u32 *)vbuf;
 	int br_tid0, br_skip, br_skip_gf;
-	int level, n = 0;
+	int level, pad, n = 0;
 
 	n = knod_gfx11_bench_prologue(buf, n);
 
@@ -434,7 +434,7 @@ static inline int kfd_ipsec_gen_ghash_bench_shader_gfx11(void *vbuf)
 
 	_E(emit_gfx11_s_waitcnt_vmcnt, I11(buf, n));
 	_E(emit_gfx11_s_endpgm, I11(buf, n));
-	while (n % 256)
+	for (pad = 0; pad < KNOD_IPSEC_SHADER_PAD_DWORDS; pad++)
 		_E(emit_gfx11_s_code_end, I11(buf, n));
 
 	return n * 4;

--- a/drivers/gpu/drm/amd/amdkfd/knod/ipsec_fused_gfx10.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/ipsec_fused_gfx10.h
@@ -140,7 +140,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 	int br_no_sdma, br_no_copy, br_not_last;
 	int br_ipv4, br_bypass, br_crypto_end;
 	int br_ipv6, br_v6_to_common;
-	int br_not_transport, li;
+	int br_not_transport, li, pad;
 	const int L3_TMP_BASE = 14;	/* v14..v23 */
 	u32 *buf = (u32 *)vbuf;
 	int br_crypto_done;
@@ -1392,13 +1392,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx10(void *vbuf)
 
 	_E(emit_gfx10_s_endpgm, I10(buf, n));
 
-	/* GFX10 RDNA2 prefetches instructions aggressively past s_endpgm.
-	 * Without an s_code_end cushion the SQC fetches garbage beyond the
-	 * shader and raises an SQC(inst) page fault at a seemingly random
-	 * address. Pad to a 256-dword boundary - same pattern the BPF GFX10
-	 * emitter (knod_bpf.c) uses on working shaders.
-	 */
-	while (n % 256)
+	for (pad = 0; pad < KNOD_IPSEC_SHADER_PAD_DWORDS; pad++)
 		_E(emit_gfx10_s_code_end, I10(buf, n));
 
 	return n * 4;

--- a/drivers/gpu/drm/amd/amdkfd/knod/ipsec_fused_gfx11.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/ipsec_fused_gfx11.h
@@ -153,7 +153,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx11(void *vbuf)
 	int br_no_sdma, br_no_copy, br_not_last;
 	int br_ipv4, br_bypass, br_crypto_end;
 	int br_ipv6, br_v6_to_common;
-	int br_not_transport, li;
+	int br_not_transport, li, pad;
 	const int L3_TMP_BASE = 14;	/* v14..v23 */
 	u32 *buf = (u32 *)vbuf;
 	int br_crypto_done;
@@ -1401,13 +1401,7 @@ static inline int kfd_ipsec_gen_fused_shader_gfx11(void *vbuf)
 
 	_E(emit_gfx11_s_endpgm, I11(buf, n));
 
-	/* GFX11 RDNA3 prefetches instructions aggressively past s_endpgm.
-	 * Without an s_code_end cushion the SQC fetches garbage beyond the
-	 * shader and raises an SQC(inst) page fault at a seemingly random
-	 * address. Pad to a 256-dword boundary - same pattern the BPF GFX11
-	 * emitter (knod_bpf.c) uses on working shaders.
-	 */
-	while (n % 256)
+	for (pad = 0; pad < KNOD_IPSEC_SHADER_PAD_DWORDS; pad++)
 		_E(emit_gfx11_s_code_end, I11(buf, n));
 
 	return n * 4;

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -1070,6 +1070,31 @@ static void knod_bpf_layout_sregs(struct knod_bpf_priv *priv,
 		knod_prog->exec_save_base + knod_prog->exec_save_pairs_used * 2;
 }
 
+/* Instruction prefetch runs past s_endpgm by up to three cachelines. */
+#define KNOD_SHADER_PAD_DWORDS		64
+
+static struct knod_insn_meta *knod_bpf_pad_shader(struct knod_bpf_priv *priv,
+						  struct knod_insn_meta *meta,
+						  struct list_head *insns)
+{
+	int j;
+
+	if (priv->isa_version < 10)
+		return meta;
+
+	for (j = 0; j < KNOD_SHADER_PAD_DWORDS; j++) {
+		if (meta->amdgpu_insns >= KNOD_META_INSNS) {
+			meta = kzalloc_obj(*meta, GFP_KERNEL);
+			if (!meta)
+				return NULL;
+			list_add_tail(&meta->l, insns);
+		}
+		knod_emit(priv, meta, s_code_end);
+	}
+
+	return meta;
+}
+
 static int knod_bpf_jit_pass_kernel(struct knod_bpf_priv *priv)
 {
 	struct list_head *lists[2];
@@ -1211,11 +1236,10 @@ static int knod_bpf_jit_pass_kernel(struct knod_bpf_priv *priv)
 
 	knod_emit(priv, epi, s_endpgm);
 
-	if (priv->isa_version >= 10) {
-		for (j = 0; j < 16 && epi->amdgpu_insns < KNOD_META_INSNS; j++)
-			knod_emit(priv, epi, s_code_end);
-	}
 	list_add_tail(&epi->l, &pass_prog.post_insns);
+
+	if (!knod_bpf_pad_shader(priv, epi, &pass_prog.post_insns))
+		return -ENOMEM;
 
 	/* Linearize prologue + epilogue into pass_prog_buf */
 	lists[0] = &pass_prog.pre_insns;
@@ -10802,30 +10826,8 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 
 	knod_emit(priv, meta, s_endpgm);
 
-	for (j = 0; j < meta->amdgpu_insns; j++)
-		insn_idx += meta->amdgpu_insn[j].size / 4;
-
-	if (priv->isa_version == 10) {
-		if (insn_idx % 256) {
-			meta = kzalloc_obj(*meta, GFP_KERNEL);
-			if (!meta)
-				return -ENOMEM;
-			list_add_tail(&meta->l, &knod_prog->post_insns);
-		}
-
-		while (insn_idx % 256) {
-			if (meta->amdgpu_insns >= KNOD_META_INSNS) {
-				meta = kzalloc_obj(*meta, GFP_KERNEL);
-				if (!meta)
-					return -ENOMEM;
-				list_add_tail(&meta->l, &knod_prog->post_insns);
-			}
-			knod_emit(priv, meta, s_code_end);
-			insn_idx +=
-				meta->amdgpu_insn[meta->amdgpu_insns - 1].size /
-				4;
-		}
-	}
+	if (!knod_bpf_pad_shader(priv, meta, &knod_prog->post_insns))
+		return -ENOMEM;
 
 	return 0;
 }

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -140,6 +140,13 @@
 #define KNOD_AMDGPU_STACK_VREG0		128
 #define KNOD_AMDGPU_STACK_VREG_MAX	255 /* 128 ~ 255 vgprs are available */
 
+/* One VGPR holds four bytes of packet, so what the cache can hold is decided
+ * by how many VGPRs sit between its base and the stack.
+ */
+#define KNOD_AMDGPU_PKT_CACHE_VREGS					\
+	(KNOD_AMDGPU_PKT_CACHE_VREG_MAX - KNOD_AMDGPU_PKT_CACHE_VREG0 + 1)
+#define MAX_PACKET_CACHE		(KNOD_AMDGPU_PKT_CACHE_VREGS * 4)
+
 #define KNOD_BPF_PROG_BUF_SIZE		32768
 
 /* Index for r64.
@@ -4202,7 +4209,7 @@ static int knod_prog_prepare(struct knod_bpf_priv *priv,
 			KNOD_AMDGPU_PAGE_BASE_VREG_LO;
 
 		knod_vset32(&pkt_cache[0], pkt_cache_start);
-		for (i = 1; i < 64; i++)
+		for (i = 1; i < KNOD_AMDGPU_STACK_VREG0 - pkt_cache_start; i++)
 			knod_vset32(&pkt_cache[i],
 						 pkt_cache[i - 1].v + 1);
 	}

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
@@ -60,7 +60,6 @@
 #define KNOD_MAX_BDS			(KNOD_BPF_BACKLOGS_MAX / KNOD_SPSC_MAX)
 
 #define MAX_KEY_SIZE		64 /* 64Bytes */
-#define MAX_PACKET_CACHE	256 /* 256Bytes */
 
 #define knod_prog_first_meta(knod_prog)					\
 	list_first_entry(&(knod_prog)->insns, struct knod_insn_meta, l)

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_ipsec.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_ipsec.h
@@ -28,6 +28,8 @@ struct napi_struct;
 struct knod_ipsec_priv;
 
 #define KNOD_IPSEC_NR_SA		256
+/* Instruction prefetch runs past s_endpgm by up to three cachelines. */
+#define KNOD_IPSEC_SHADER_PAD_DWORDS	64
 /* The shader-dispatch KAT installs one fake SA per fused_sub entry, so
  * its maximum batch size is bounded by NR_SA. Keep separate from
  * KNOD_IPSEC_PKT_BATCH so production can run larger batches without


### PR DESCRIPTION
Three latent bugs found while working out what the BPF JIT may and may not
touch in the VGPR file. All are cases where a documented hardware limit was
restated as a number that no longer matched, so nothing looked wrong until
the shader happened to land badly.

### Shader end padding

RDNA runs instruction prefetch up to three cachelines past `s_endpgm`, so the
64 dwords beyond the end of a shader have to stay mapped. When they do not, the
SQC faults on an address unrelated to the shader.

None of the emission sites got this right:

| site | what it did |
| --- | --- |
| BPF pass kernel | 16 dwords, and gave up silently if the meta filled |
| BPF main JIT | padded to a 256-dword boundary, and only for gfx10 |
| ipsec, 5 sites | padded to a 256-dword boundary |

Padding to a boundary falls under 64 dwords whenever a shader ends in the last
quarter before one — a quarter of the time — and emits nothing at all when it
ends exactly on one. The gfx11 arm of the main JIT was missing outright, which
has not bitten yet only because gfx11 BPF is still gated off.

Both BPF sites now share one helper that emits the full 64 dwords and allocates
another meta when the current one fills. The ipsec sites use a constant in
`knod_ipsec.h`.

### Packet cache bound

The packet cache occupies the VGPRs between its base and the BPF stack, v70
through v127, which is 58 registers or 232 bytes. `MAX_PACKET_CACHE` said 256,
so a program touching a packet offset past 232 passed the check and then had its
cache spill into v128 and up — the stack. The descriptor table was filled to 64
entries for the same reason, naming registers that belong to the stack whether
or not anything went on to use them.

The limit now comes from the region instead of being stated a second time, and
the table stops at the last register the cache owns.

### Notes

Commits are split so the ipsec change stays separate from the two core ones.

Built and booted. The padding change is not directly observable — it widens a
margin — so what was verified is that the gfx11 ipsec KAT and the BPF path still
pass with the larger padding in place.