### PR TITLE
drm/amdkfd: knod: disable GFX11 FLAT SADDR with NULL, not 127

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_gfx11_insn.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_gfx11_insn.h
@@ -1428,8 +1428,10 @@ union amdgcn_gfx11_insn {
 
 #define GFX11_VOP3_UNUSED_SRC		0
 #define GFX11_VOP3SD_SDST_VCC_LO	106
-/* 0x7f also disables SADDR and, unlike NULL, is numbered the same on RDNA2. */
-#define GFX11_FLAT_SADDR_NULL		0x7f
+/* SADDR is disabled by writing NULL to it, and no two generations number NULL
+ * the same: 127 on GCN5, 125 on RDNA2, 124 here.
+ */
+#define GFX11_FLAT_SADDR_NULL		GFX11_SRC_NULL
 #define GFX11_DS_LDS			0
 
 /* S_WAITCNT SIMM16 (RDNA3 16.5): EXP[2:0], LGKM[9:4], VM[15:10].  This


### PR DESCRIPTION
A global load or store with no scalar base disables SADDR by writing NULL to
it, and every generation numbers NULL differently: 127 on GCN5, 125 on RDNA2,
124 on RDNA3. The GFX11 emitter was writing 127, which is what GCN5 wants.

```
	gfx9    0x7f    GFX9_FLAT_SADDR_DISABLE  = 0x7f   ok
	gfx10   0x7d    GFX10_FLAT_SADDR_DISABLE = 125    ok
	gfx11   0x7c    GFX11_FLAT_SADDR_NULL    = 0x7f   wrong
```

The constant was named for NULL and did not hold it, and its comment claimed
127 was generation-independent — which the GFX10 emitter a few hundred lines
away already contradicts.

### How it turned up

The hardware has been accepting 127 all along, so the KAT passed and nothing
looked wrong. It surfaced when the shader was disassembled with LLVM rather
than with the driver's own disassembler, which decoded knod's encodings by
knod's own rules and so could never disagree with them:

```
	before   0034: dc560000    .long 0xdc560000
	after    0034: dc560000 097c0003   global_load_b64 v[9:10], v[3:4], off
	         003c: dc560010 057c0003   global_load_b64 v[5:6], v[3:4], off offset:16
```

### Testing

gfx11 (RDNA3), ipsec KAT passes. The full shader now disassembles with no
undecodable instructions left.