### PR TITLE
drm/amdkfd: knod: make the BPF prologue the same every time

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -848,6 +848,9 @@ static struct knod_bpf_work_sq *knod_prepare_bpf(struct knod_bpf_priv *priv)
 	param->nr_backlogs = backlogs;
 	param->nr_queues = priv->nr_works;
 	param->spsc_stride = ALIGN(sizeof(struct spsc_bd), SMP_CACHE_BYTES);
+	param->batch_shift = ilog2(priv->batch_size);
+	param->wg_shift = ilog2(knod_bpf_workgroups);
+	param->page_shift = PAGE_SHIFT;
 	for (i = 0; i < priv->nr_works; i++) {
 		param->pass_count[i] = 0;
 		param->pass_meta_buf_gaddr[i] = priv->pass_meta_buf ?
@@ -2825,15 +2828,15 @@ static struct knod_bpf_priv *__knod_accel_xdp_init(struct knod_accel *accel,
 		return ERR_PTR(-ENOMEM);
 
 	INIT_LIST_HEAD(&priv->list);
-	if (knod_bpf_workgroups % 64) {
-		knod_bpf_workgroups /= 64;
-		knod_bpf_workgroups++;
-		knod_bpf_workgroups *= 64;
-	}
-
 	if (knod_bpf_workgroups < KNOD_BPF_WORKGROUPS_MIN ||
 	    knod_bpf_workgroups > KNOD_BPF_WORKGROUPS_MAX)
 		knod_bpf_workgroups = KNOD_BPF_WORKGROUPS_DEFAULT;
+	/* Round to a power of two so the prologue can reach a lane's slot with
+	 * a shift.  A multiply would need the count itself, which is a module
+	 * parameter and so cannot be an immediate in a prebuilt shader.
+	 */
+	else if (!is_power_of_2(knod_bpf_workgroups))
+		knod_bpf_workgroups = 1U << ilog2(knod_bpf_workgroups);
 
 	if (knod_bpf_expire < KNOD_BPF_EXPIRE_MIN ||
 	    knod_bpf_expire > KNOD_BPF_EXPIRE_MAX)
@@ -3810,7 +3813,6 @@ static int knod_prog_prepare_insns(struct knod_bpf_priv *priv,
 	struct amdgcn_param64 param64[3];
 	struct amdgcn_param32 param[10];
 	struct knod_insn_meta *meta;
-	int bs_shift;
 
 	meta = kzalloc_obj(*meta, GFP_KERNEL);
 	if (!meta)
@@ -3848,20 +3850,6 @@ static int knod_prog_prepare_insns(struct knod_bpf_priv *priv,
 	 */
 	knod_emit(priv, meta, v_bfe_i32, param[0], param[1], param[2],
 		  param[3]);
-	if (priv->batch_size > knod_bpf_workgroups) {
-		/* local_idx = workgroup_id_x * workgroup_size_x
-		 * + workitem_id.
-		 */
-		knod_vset32(&param[0], KNOD_AMDGPU_TMP_VREG5_LO);
-		knod_sset32(&param[1], KNOD_AMDGPU_WORKGROUP_ID_X_SREG);
-		knod_iset32(&param[2], knod_bpf_workgroups);
-		knod_emit(priv, meta,
-			v_mul_lo_u32, param[0], param[1], param[2]);
-		knod_vset32(&param[0], KNOD_AMDGPU_IDX_VREG);
-		knod_vset32(&param[1], KNOD_AMDGPU_TMP_VREG5_LO);
-		knod_vset32(&param[2], KNOD_AMDGPU_IDX_VREG);
-		knod_emit(priv, meta, v_add_u32, param[0], param[1], param[2]);
-	}
 	/* set frame pointer to 0 */
 	knod_sset32(&param[0], KNOD_AMDGPU_FRAME_POINTER_SREG);
 	knod_iset32(&param[1], 0);
@@ -3869,11 +3857,37 @@ static int knod_prog_prepare_insns(struct knod_bpf_priv *priv,
 	/* wait for s_load_dwordx2 (kernarg_address) */
 	knod_emit(priv, meta, s_waitcnt_vmcnt_lgkmcnt);
 
-	/* load {nr_backlogs, _pad} from param (offset 0, 8-byte aligned) */
+	/* The shift counts, in the two pairs they are laid out in.  They stay
+	 * live until the DATA computation near the end of the prologue, so they
+	 * go in scalars nothing else here touches.
+	 */
 	knod_sset32(&param[0], KNOD_AMDGPU_TMP_SREG1_LO);
 	knod_sset32(&param[1], KNOD_AMDGPU_PARAM_SREG_LO);
-	knod_emit(priv, meta, s_load_dwordx2, param[0], param[1], 0);
+	knod_emit(priv, meta, s_load_dwordx2, param[0], param[1],
+		  offsetof(struct knod_bpf_param, batch_shift));
+	knod_sset32(&param[0], KNOD_AMDGPU_TMP_SREG2_LO);
+	knod_emit(priv, meta, s_load_dwordx2, param[0], param[1],
+		  offsetof(struct knod_bpf_param, page_shift));
 	knod_emit(priv, meta, s_waitcnt_vmcnt_lgkmcnt);
+
+	if (priv->batch_size > knod_bpf_workgroups) {
+		/* local_idx = (workgroup_id_x << wg_shift) + workitem_id.
+		 * v_lshlrev_b32 takes the count in src0, where a scalar is
+		 * allowed, but shifts a VGPR - so the group id comes across
+		 * first.
+		 */
+		knod_vset32(&param[0], KNOD_AMDGPU_TMP_VREG7_LO);
+		knod_sset32(&param[1], KNOD_AMDGPU_WORKGROUP_ID_X_SREG);
+		knod_emit(priv, meta, v_mov_b32_e32, param[0], param[1]);
+		knod_sset32(&param[1], KNOD_AMDGPU_TMP_SREG1_HI);
+		knod_vset32(&param[2], KNOD_AMDGPU_TMP_VREG7_LO);
+		knod_emit(priv, meta, v_lshlrev_b32, param[0], param[1],
+			  param[2]);
+		knod_vset32(&param[0], KNOD_AMDGPU_IDX_VREG);
+		knod_vset32(&param[1], KNOD_AMDGPU_TMP_VREG7_LO);
+		knod_vset32(&param[2], KNOD_AMDGPU_IDX_VREG);
+		knod_emit(priv, meta, v_add_u32, param[0], param[1], param[2]);
+	}
 
 	/* NOTE: the bounds check `EXEC &= (tid < count)` is deferred until
 	 * after the queue descriptor load (queue<->workgroup binding).
@@ -3897,7 +3911,6 @@ static int knod_prog_prepare_insns(struct knod_bpf_priv *priv,
 	 * tid for use as local_idx in the slot-address step.
 	 * =========================================================
 	 */
-	bs_shift = ilog2(priv->batch_size);
 
 	/* a. queue_id = workgroup_id_y (broadcast scalar to VGPR LO). */
 	knod_vset32(&param[0], KNOD_AMDGPU_TMP_VREG0_LO);
@@ -3979,9 +3992,16 @@ static int knod_prog_prepare_insns(struct knod_bpf_priv *priv,
 	 *    batch_size is rounded down to a power of two at start so the
 	 *    shift is exact.
 	 */
-	knod_vset32(&param[0], KNOD_AMDGPU_IDX_VREG);
+	/* The queue id comes across to a VGPR first: with the shift count now a
+	 * scalar too, leaving it in one would put two on the constant bus, which
+	 * GCN5 does not allow.
+	 */
+	knod_vset32(&param[0], KNOD_AMDGPU_TMP_VREG7_LO);
 	knod_sset32(&param[1], KNOD_AMDGPU_WORKGROUP_ID_Y_SREG);
-	knod_iset32(&param[2], bs_shift);
+	knod_emit(priv, meta, v_mov_b32_e32, param[0], param[1]);
+	knod_vset32(&param[0], KNOD_AMDGPU_IDX_VREG);
+	knod_vset32(&param[1], KNOD_AMDGPU_TMP_VREG7_LO);
+	knod_sset32(&param[2], KNOD_AMDGPU_TMP_SREG1_LO);
 	knod_vset32(&param[3], KNOD_AMDGPU_IDX_VREG);
 	knod_emit(priv, meta, v_lshl_add_u32, param[0], param[1],
 		  param[2], param[3]);
@@ -4068,11 +4088,14 @@ static int knod_prog_prepare_insns(struct knod_bpf_priv *priv,
 	 *    Compute directly into DATA_VREG (v64:v65).
 	 */
 	knod_vset32(&param[0], KNOD_AMDGPU_DATA_VREG_LO);
-	knod_iset32(&param[1], PAGE_SHIFT);
+	knod_sset32(&param[1], KNOD_AMDGPU_TMP_SREG2_LO);
 	knod_vset32(&param[2], KNOD_AMDGPU_TMP_VREG6_HI);
 	knod_emit(priv, meta, v_lshlrev_b32, param[0], param[1], param[2]);
+	/* The high half takes what the low half shifted out, 32 - page_shift. */
+	knod_emit(priv, meta, s_sub_u32, KNOD_AMDGPU_TMP_SREG2_HI,
+		  AMDGCN_SREG_INTEGER_0 + 32, KNOD_AMDGPU_TMP_SREG2_LO);
 	knod_vset32(&param[0], KNOD_AMDGPU_DATA_VREG_HI);
-	knod_iset32(&param[1], 32 - PAGE_SHIFT);
+	knod_sset32(&param[1], KNOD_AMDGPU_TMP_SREG2_HI);
 	knod_emit(priv, meta, v_lshrrev_b32, param[0], param[1], param[2]);
 
 	/* data = base_gaddr + page_gaddr */

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -25,11 +25,15 @@
 #include <net/knod.h>
 #include <net/netdev_rx_queue.h>
 
-/*+--------+---------+-------+------+--+-----+------+------+--------+
- *| v0-v21 | v22-v59 |v60-v61| v62  |63|64-65|66-67 |68-69 | v70-127|
- *+--------+---------+-------+------+--+-----+------+------+--------+
- *|BPF REGS|TMP REGS |CTX REG| WIDX |R |DATA |D_END |PGBASE|PKTCACHE|
- *+--------+---------+-------+------+--+-----+------+------+--------+
+/*+--------+---------+------+-------+----+--+-----+------+------+--------+
+ *| v0-v21 | v22-v57 |58-59 |v60-v61| 62 |63|64-65|66-67 |68-69 | v70-127|
+ *+--------+---------+------+-------+----+--+-----+------+------+--------+
+ *|BPF REGS|TMP REGS | SLOT |CTX REG|WIDX|R |DATA |D_END |PGBASE|PKTCACHE|
+ *+--------+---------+------+-------+----+--+-----+------+------+--------+
+ * Everything from SLOT rightwards is set in the prologue and read later, so
+ * nothing there may be used as scratch.  TMP is the opposite: it holds nothing
+ * across the program, which is what lets prebuilt routines spliced into it
+ * clobber the lot.
  *+-----------------+
  *| v128-v255       |
  *+-----------------+
@@ -39,7 +43,7 @@
 
 /* Temp register map
  *+-------------+-------------+---------------+---------------+
- *|TREG0 - TREG2|TREG3 - TREG9|TREG10 - TREG16|TREG17 - TREG18|
+ *|TREG0 - TREG2|TREG3 - TREG9|TREG10 - TREG16|     TREG17    |
  *+-------------+-------------+---------------+---------------+
  *| General Use | Key cache A |   Key in MAP  | JHASH Temp Reg|
  *+-------------+-------------+---------------+---------------+
@@ -106,24 +110,20 @@
 #define KNOD_AMDGPU_TMP_VREG16_HI	55
 #define KNOD_AMDGPU_TMP_VREG17_LO	56
 #define KNOD_AMDGPU_TMP_VREG17_HI	57
-#define KNOD_AMDGPU_TMP_VREG18_LO	58
-#define KNOD_AMDGPU_TMP_VREG18_HI	59
-#define KNOD_AMDGPU_TMP_VREG_MAX	KNOD_AMDGPU_TMP_VREG18_HI
+#define KNOD_AMDGPU_TMP_VREG_MAX	KNOD_AMDGPU_TMP_VREG17_HI
+/*
+ * slot_addr (spsc_bd GTT address) is set in the prologue and read in the
+ * epilogue, so it sits above the scratch registers rather than inside them.
+ * It used to share v62:v63 with IDX_VREG, which meant the backlog index had
+ * to be copied out to a scratch register to survive - a value living across
+ * the whole program in space nothing else could then rely on.
+ */
+#define KNOD_AMDGPU_SLOT_VREG_LO	58
+#define KNOD_AMDGPU_SLOT_VREG_HI	59
 #define KNOD_AMDGPU_CTX_VREG_LO		60
 #define KNOD_AMDGPU_CTX_VREG_HI		61
 #define KNOD_AMDGPU_IDX_VREG		62
 #define KNOD_AMDGPU_RESERVED		63
-/*
- * After prologue step 4, IDX_VREG is no longer needed.
- * v62:v63 are repurposed to hold slot_addr (spsc_bd GTT address)
- * through BPF execution and into the epilogue.
- *
- * BACKLOG_IDX_VREG (v58) saves the backlog index from IDX_VREG
- * before step 6 overwrites it.  Used in epilogue for XDP_PASS.
- */
-#define KNOD_AMDGPU_BACKLOG_IDX_VREG	KNOD_AMDGPU_TMP_VREG18_LO /* v58 */
-#define KNOD_AMDGPU_SLOT_VREG_LO	KNOD_AMDGPU_IDX_VREG	/* v62 */
-#define KNOD_AMDGPU_SLOT_VREG_HI	KNOD_AMDGPU_RESERVED	/* v63 */
 /*
  * DATA/DATA_END VGPRs: hold packet gaddr and end address.
  * Set in prologue, read by BPF ctx->data / ctx->data_end accesses.
@@ -172,7 +172,6 @@
 #define TREG64_15			15
 #define TREG64_16			16
 #define TREG64_17			17
-#define TREG64_18			18
 
 #define MAX_MAP_KEY_SIZE		56
 
@@ -217,9 +216,7 @@
 #define TREG32_16_HI			33
 #define TREG32_17_LO			34
 #define TREG32_17_HI			35
-#define TREG32_18_LO			36
-#define TREG32_18_HI			37
-#define TREG32_MAX			TREG32_18_HI
+#define TREG32_MAX			TREG32_17_HI
 
 /*+--------+--------------------------------------+---+---+
  *| s[0:3] |s[4:5] s[6:7] s[8:9] s[10:11] s[12:13]|s14|s15|
@@ -337,8 +334,9 @@ static const char * const bl_labels[] = {
 };
 
 static LIST_HEAD(priv_list);
+/* r64[0..17] describe the scratch pairs; r64[19] describes CTX. */
 struct amdgcn_param64 r64[20], sr64[6], p64[4], bpf_reg64[11];
-struct amdgcn_param32 r32[40]; /* last two is CTX */
+struct amdgcn_param32 r32[36];
 struct amdgcn_param32 stack[128];
 struct amdgcn_param32 pkt_cache[64];
 
@@ -1228,8 +1226,8 @@ static int knod_bpf_jit_pass_kernel(struct knod_bpf_priv *priv)
 	knod_vset32(&p[2], KNOD_AMDGPU_TMP_VREG9_LO);
 	knod_emit(priv, epi, v_add_u32, p[0], p[1], p[2]);
 
-	/* global_store_short pass_indices[old_val], BACKLOG_IDX_VREG */
-	knod_vset32(&p[0], KNOD_AMDGPU_BACKLOG_IDX_VREG);
+	/* global_store_short pass_indices[old_val], IDX_VREG */
+	knod_vset32(&p[0], KNOD_AMDGPU_IDX_VREG);
 	knod_vset32(&p[1], KNOD_AMDGPU_TMP_VREG9_LO);
 	knod_emit(priv, epi, global_store_short, p[0], p[1],
 		  offsetof(struct knod_bpf_param, pass_indices));
@@ -4050,14 +4048,6 @@ static int knod_prog_prepare_insns(struct knod_bpf_priv *priv,
 	knod_vset32(&param[2], KNOD_AMDGPU_TMP_VREG5_LO);
 	knod_emit(priv, meta, v_and_b32_e32, param[0], param[1], param[2]);
 
-	/* Save backlog index before step 6 overwrites IDX_VREG -> SLOT_VREG.
-	 * v_mov_b32 BACKLOG_IDX_VREG(v58), IDX_VREG(v62)
-	 * Used in epilogue for XDP_PASS pass_indices[] write.
-	 */
-	knod_vset32(&param[0], KNOD_AMDGPU_BACKLOG_IDX_VREG);
-	knod_vset32(&param[1], KNOD_AMDGPU_IDX_VREG);
-	knod_emit(priv, meta, v_mov_b32_e32, param[0], param[1]);
-
 	/* 6. slot_addr = pool_gaddr + slot * spsc_stride, where
 	 *    spsc_stride = ALIGN(sizeof(spsc_bd), SMP_CACHE_BYTES)
 	 *    Compute directly into SLOT_VREG (v62:v63).
@@ -4200,7 +4190,6 @@ static int knod_prog_prepare(struct knod_bpf_priv *priv,
 	knod_vset64(&r64[15], KNOD_AMDGPU_TMP_VREG15_LO);
 	knod_vset64(&r64[16], KNOD_AMDGPU_TMP_VREG16_LO);
 	knod_vset64(&r64[17], KNOD_AMDGPU_TMP_VREG17_LO);
-	knod_vset64(&r64[18], KNOD_AMDGPU_TMP_VREG18_LO);
 	knod_vset64(&r64[19], KNOD_AMDGPU_CTX_VREG_LO);
 
 	knod_sset64(&sr64[0], KNOD_AMDGPU_TMP_SREG0_LO);
@@ -4223,7 +4212,7 @@ static int knod_prog_prepare(struct knod_bpf_priv *priv,
 	knod_vset64(&bpf_reg64[10], KNOD_AMDGPU_FRAME_POINTER_VREG_LO);
 
 	knod_vset32(&r32[0], KNOD_AMDGPU_TMP_VREG0_LO);
-	for (i = 1; i < 40; i++)
+	for (i = 1; i < 36; i++)
 		knod_vset32(&r32[i], r32[i - 1].v + 1);
 
 	if (knod_bpf_pkt_cache) {
@@ -10833,11 +10822,11 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 	knod_emit(priv, meta, v_add_u32, p[0], p[1], p[2]);
 
 	/* global_store_short pass_indices[old_val],
-	 *                    BACKLOG_IDX_VREG
+	 *                    IDX_VREG
 	 * dst=data, src=addr in wrapper convention
 	 */
 	knod_vset32(&p[0],
-				 KNOD_AMDGPU_BACKLOG_IDX_VREG);
+				 KNOD_AMDGPU_IDX_VREG);
 	knod_vset32(&p[1], KNOD_AMDGPU_TMP_VREG9_LO);
 	knod_emit(priv, meta, global_store_short, p[0], p[1],
 		  offsetof(struct knod_bpf_param, pass_indices));

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
@@ -172,6 +172,15 @@ struct knod_bpf_param {
 	u32 nr_queues;
 	u32 spsc_stride;
 	u32 _pad0;
+	/* Shift counts the prologue needs.  They follow the module parameters,
+	 * so a shader built once cannot carry them as immediates; it loads them
+	 * from here instead.  Kept in pairs the prologue can reach with the
+	 * two-dword scalar load it already has.
+	 */
+	u32 batch_shift;
+	u32 wg_shift;
+	u32 page_shift;
+	u32 _pad1;
 	u64 ktime_ns;		/* snapshot of ktime_get_ns() at dispatch */
 	u32 pass_count[KNOD_SPSC_MAX];	/* per-queue atomic XDP_PASS counter */
 	/* per-queue GTT pass_meta_buf GPU addr */


### PR DESCRIPTION
Groundwork for building the prologue ahead of time rather than emitting it.
Two things stood in the way, and both are worth fixing on their own terms.

### The shifts were immediates

The prologue reaches a lane's slot with three shifts - `ilog2(batch_size)`,
the workgroup count, and `PAGE_SHIFT`. All three were baked into the
instructions, so the bytes differed between one dispatch and the next.

They are now dispatch parameters, loaded with the scalar load the prologue was
already doing. That load fetched `nr_backlogs` and `nr_queues`, which nothing
read - left over from a bounds check that moved elsewhere.

The workgroup count becomes a shift, so it is rounded to a power of two. It was
rounded to a multiple of 64 before, which allowed 192; nobody runs that.

Cost is four instructions once per wave: two `v_mov`, because a shift count in
a scalar puts a second value on the constant bus and GCN5 allows one, and one
`s_sub` for `32 - page_shift`.

### slot_addr lived in the scratch registers

`slot_addr` shared v62:v63 with `IDX_VREG` on the grounds that the index was
finished with. It was not - the epilogue writes `pass_indices[]` with it - so
the prologue copied the index into a scratch register to keep it. That left a
value alive across the whole program in the middle of the range everything
else treats as scratch.

`slot_addr` moves to v58:v59 and `IDX_VREG` keeps what it holds. The copy goes,
and nothing survives in the scratch registers from prologue to epilogue.
jhash's four temporaries move down with the range, which now ends at v57.

```
	 v0-v21   BPF REGS
	v22-v57   TMP REGS      was v22-v59
	v58-v59   SLOT          was TMP, and BACKLOG_IDX squatting in it
	v60-v61   CTX
	    v62   IDX           no longer reused
```

### Testing

V620 (gfx1030), kondor with a hash map, traffic passing.

```
	prologue    the three shifts read from the dispatch parameters
	slot        computed into v58:v59, the copy gone
	jhash       v54-v57, clear of the slot registers
	encoding    every instruction reads back through llvm-mc
```

The last one matters for the jhash move: the temporaries had to come down four
registers, and a wrong register there would put lookups in the wrong bucket
rather than fault.