### PR TITLE
drm/amdkfd: knod: take the slot stride from the dispatch too

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -849,6 +849,7 @@ static struct knod_bpf_work_sq *knod_prepare_bpf(struct knod_bpf_priv *priv)
 	param->batch_shift = ilog2(priv->batch_size);
 	param->wg_shift = ilog2(knod_bpf_workgroups);
 	param->page_shift = PAGE_SHIFT;
+	param->spsc_shift = ilog2(param->spsc_stride);
 	for (i = 0; i < priv->nr_works; i++) {
 		param->pass_count[i] = 0;
 		param->pass_meta_buf_gaddr[i] = priv->pass_meta_buf ?
@@ -3855,9 +3856,9 @@ static int knod_prog_prepare_insns(struct knod_bpf_priv *priv,
 	/* wait for s_load_dwordx2 (kernarg_address) */
 	knod_emit(priv, meta, s_waitcnt_vmcnt_lgkmcnt);
 
-	/* The shift counts, in the two pairs they are laid out in.  They stay
-	 * live until the DATA computation near the end of the prologue, so they
-	 * go in scalars nothing else here touches.
+	/* The four shift counts, in the two pairs they are laid out in.  They
+	 * stay live until the DATA computation near the end of the prologue, so
+	 * they go in scalars nothing else here touches.
 	 */
 	knod_sset32(&param[0], KNOD_AMDGPU_TMP_SREG1_LO);
 	knod_sset32(&param[1], KNOD_AMDGPU_PARAM_SREG_LO);
@@ -4053,8 +4054,7 @@ static int knod_prog_prepare_insns(struct knod_bpf_priv *priv,
 	 *    Compute directly into SLOT_VREG (v62:v63).
 	 */
 	knod_vset32(&param[0], KNOD_AMDGPU_SLOT_VREG_LO);
-	knod_iset32(&param[1],
-		ilog2(ALIGN(sizeof(struct spsc_bd), SMP_CACHE_BYTES)));
+	knod_sset32(&param[1], KNOD_AMDGPU_TMP_SREG2_HI);
 	knod_emit(priv, meta, v_lshlrev_b32, param[0], param[1], param[2]);
 	/* slot_addr = pool_gaddr + slot_offset */
 	knod_vset32(&param[1], KNOD_AMDGPU_TMP_VREG1_LO);
@@ -4082,10 +4082,10 @@ static int knod_prog_prepare_insns(struct knod_bpf_priv *priv,
 	knod_vset32(&param[2], KNOD_AMDGPU_TMP_VREG6_HI);
 	knod_emit(priv, meta, v_lshlrev_b32, param[0], param[1], param[2]);
 	/* The high half takes what the low half shifted out, 32 - page_shift. */
-	knod_emit(priv, meta, s_sub_u32, KNOD_AMDGPU_TMP_SREG2_HI,
+	knod_emit(priv, meta, s_sub_u32, KNOD_AMDGPU_TMP_SREG3_LO,
 		  AMDGCN_SREG_INTEGER_0 + 32, KNOD_AMDGPU_TMP_SREG2_LO);
 	knod_vset32(&param[0], KNOD_AMDGPU_DATA_VREG_HI);
-	knod_sset32(&param[1], KNOD_AMDGPU_TMP_SREG2_HI);
+	knod_sset32(&param[1], KNOD_AMDGPU_TMP_SREG3_LO);
 	knod_emit(priv, meta, v_lshrrev_b32, param[0], param[1], param[2]);
 
 	/* data = base_gaddr + page_gaddr */

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
@@ -180,7 +180,7 @@ struct knod_bpf_param {
 	u32 batch_shift;
 	u32 wg_shift;
 	u32 page_shift;
-	u32 _pad1;
+	u32 spsc_shift;
 	u64 ktime_ns;		/* snapshot of ktime_get_ns() at dispatch */
 	u32 pass_count[KNOD_SPSC_MAX];	/* per-queue atomic XDP_PASS counter */
 	/* per-queue GTT pass_meta_buf GPU addr */


### PR DESCRIPTION
Follows #9, which moved the prologue's other shift counts out of the
instructions and into the dispatch parameters so that the prologue comes out
the same every time.

One was left: the slot stride, `ilog2(ALIGN(sizeof(struct spsc_bd),
SMP_CACHE_BYTES))`. It is a property of the kernel the shader was built with
rather than of the program, so it did not vary between dispatches - but it
does vary between kernels, which is enough to stop the prologue being built
ahead of time.

It fits in the padding after `page_shift`, so it arrives on the scalar load
that was already fetching that one: no extra load. The subtraction producing
`32 - page_shift` moves to another scalar to make room.

With this, the fixed part of the prologue - everything up to the exec-save
initialisation, 74 dwords - holds no value that follows anything but struct
layout:

```
	v_bfe_i32         v62, v0, 0, 10        tid, 10 bits
	v_lshlrev_b32_e32 v36, s19, v36         wg_shift
	v_lshl_add_u32    v62, v36, s18, v62    batch_shift
	v_lshlrev_b32_e32 v58, s21, v32         spsc_shift
	v_lshlrev_b32_e32 v64, s20, v35         page_shift
	s_sub_u32         s22, 32, s20
	v_lshrrev_b32_e32 v65, s22, v35
	v_lshrrev_b32_e32 v66, 16, v34          spsc_bd off/len, high half
```

The two immediates left are field extractions.

The two parts after it stay variable and stay in the kernel: the exec-save
initialisation runs once per pair the program's control flow needs, and the
packet-cache preload once per 16 bytes it reaches into.

### Testing

V620 (gfx1030), kondor with a hash map, traffic passing. The slot address is
what this changes, so a wrong shift reads the wrong spsc_bd and the packet
length and offset come out wrong rather than faulting.