### PR TITLE
drm/amdkfd: knod: take the whole pass kernel from the blob, require the core one

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/kfd_knod.c
+++ b/drivers/gpu/drm/amd/amdkfd/kfd_knod.c
@@ -879,25 +879,19 @@ err_mem:
 }
 
 /*
- * Write a minimal no-op kernel into the kernel BO so that any dispatch
- * before a real shader (BPF/IPsec/MACsec/WG) is loaded executes a
- * harmless s_endpgm instead of faulting on uninitialised VRAM.
+ * A dispatch before any feature has loaded a shader runs this instead of
+ * faulting on uninitialised VRAM: end the wave, then padding, because the
+ * instruction prefetcher reads past the end of one.
  *
  * Layout:
  *   [0..63]     kernel_descriptor  (kernel_code_entry_byte_offset = 256)
- *   [256..259]  s_endpgm
- *   [260..1023] s_code_end padding (GFX10+ SQC prefetch safety)
+ *   [256..1023] the blob's default kernel
  */
 #define KNOD_DEFAULT_KD_ENTRY_OFFSET	256
-/* SOPP encoding (0x17f) with the generation's S_ENDPGM opcode: 1 up to
- * RDNA2, 48 on RDNA3.  S_CODE_END is opcode 31 on all of them.
- */
-#define KNOD_S_ENDPGM			0xBF810000u
-#define KNOD_S_ENDPGM_GFX11		0xBFB00000u
-#define KNOD_S_CODE_END			0xBF9F0000u
 
-/* Optional, every time.  Without a file the caller does whatever it did before
- * there were any, so a missing one is not worth a warning.
+/* Whether a missing file is fatal is the caller's to decide - the JIT still
+ * has its own emission to fall back on, the core does not - so say nothing
+ * louder than that it was not there.
  */
 int knod_blob_load(struct knod *knod, struct knod_blob *blob, const char *what)
 {
@@ -1003,7 +997,7 @@ const u32 *knod_blob_find(const struct knod_blob *blob, u32 kind,
 }
 EXPORT_SYMBOL(knod_blob_find);
 
-static void knod_init_default_kernel(struct knod *knod)
+static int knod_init_default_kernel(struct knod *knod)
 {
 	struct kernel_descriptor *kd = knod->kernels[0]->kaddr;
 	u32 *code = (u32 *)((u8 *)knod->kernels[0]->kaddr +
@@ -1011,8 +1005,7 @@ static void knod_init_default_kernel(struct knod *knod)
 	struct knod_blob blob = {};
 	const u32 *built;
 	u32 len, room;
-	bool done;
-	int i;
+	int err;
 
 	memset(kd, 0, sizeof(*kd));
 	kd->kernel_code_entry_byte_offset = KNOD_DEFAULT_KD_ENTRY_OFFSET;
@@ -1028,20 +1021,26 @@ static void knod_init_default_kernel(struct knod *knod)
 
 	room = 1024 - KNOD_DEFAULT_KD_ENTRY_OFFSET;
 
-	if (!knod_blob_load(knod, &blob, "core")) {
-		built = knod_blob_find(&blob, KNOD_BLOB_DEFAULT_KERNEL, 0, &len);
-		done = built && len <= room;
-		if (done)
-			memcpy(code, built, len);
-		knod_blob_free(&blob);
-		if (done)
-			return;
+	err = knod_blob_load(knod, &blob, "core");
+	if (err) {
+		pr_err("knod: no core blob, cannot bring up a queue\n");
+		return err;
 	}
 
-	code[0] = knod->isa_version >= 11 ? KNOD_S_ENDPGM_GFX11 :
-					   KNOD_S_ENDPGM;
-	for (i = 1; i < room / 4; i++)
-		code[i] = KNOD_S_CODE_END;
+	built = knod_blob_find(&blob, KNOD_BLOB_DEFAULT_KERNEL, 0, &len);
+	if (!built) {
+		pr_err("knod: core blob has no default kernel\n");
+		err = -EINVAL;
+	} else if (len > room) {
+		pr_err("knod: default kernel is %u bytes, room for %u\n",
+		       len, room);
+		err = -EINVAL;
+	} else {
+		memcpy(code, built, len);
+	}
+
+	knod_blob_free(&blob);
+	return err;
 }
 
 #define KNOD_DEFAULT_BATCH	64
@@ -1258,7 +1257,9 @@ static int knod_alloc_ctx_init(struct knod *knod, int id, void **doorbell,
 		knod->kernels[0] = NULL;
 		goto err_gen_pool_destroy;
 	}
-	knod_init_default_kernel(knod);
+	err = knod_init_default_kernel(knod);
+	if (err)
+		goto err_free_kernel;
 
 	/*
 	 * Second dispatch slot for the BPF ping-pong swap, allocated right

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -1192,10 +1192,55 @@ static u8 *knod_meta_write(const struct knod_insn_meta *meta, u8 *ptr,
 	return ptr;
 }
 
+/* Nothing about the pass kernel follows a program, so unlike a translated one
+ * it is prebuilt whole rather than in pieces with the program's code between.
+ */
+static int knod_bpf_pass_kernel_insns(struct knod_bpf_priv *priv,
+				      struct knod_prog *pass_prog)
+{
+	struct knod_insn_meta *meta;
+	struct amdgcn_param32 p[2];
+	const u32 *blob;
+	u32 size;
+	int err;
+
+	if (knod_bpf_jit_engine) {
+		blob = knod_blob_find(&priv->blob, KNOD_BLOB_PASS_KERNEL, 0,
+				      &size);
+		if (blob) {
+			meta = kzalloc_obj(*meta, GFP_KERNEL);
+			if (!meta)
+				return -ENOMEM;
+
+			meta->blob = blob;
+			meta->blob_size = size;
+			list_add_tail(&meta->l, &pass_prog->pre_insns);
+			return 0;
+		}
+		pr_warn_once("knod_bpf: no prebuilt pass kernel; emitting it\n");
+	}
+
+	err = knod_prog_prepare_insns(priv, pass_prog);
+	if (err)
+		return err;
+
+	/* The pass kernel ends the way every program does, so it ends with the
+	 * same code.  What it publishes it settles first: every lane counts as
+	 * having finished, and what they finished with is PASS.
+	 */
+	meta = knod_prog_pre_last_meta(pass_prog);
+	knod_emit(priv, meta, s_mov_b64, pass_prog->done_mask_sreg,
+		  pass_prog->initial_exec_sreg);
+	knod_vset32(&p[0], KNOD_AMDGPU_VREG0_LO);
+	knod_iset32(&p[1], XDP_PASS);
+	knod_emit(priv, meta, v_mov_b32_e32, p[0], p[1]);
+
+	return knod_bpf_emit_epilogue(priv, pass_prog, false);
+}
+
 static int knod_bpf_jit_pass_kernel(struct knod_bpf_priv *priv)
 {
 	struct knod_insn_meta *meta, *tmp;
-	struct amdgcn_param32 p[3];
 	struct knod *knod = priv->knod;
 	struct knod_prog pass_prog;
 	struct list_head *lists[2];
@@ -1213,24 +1258,9 @@ static int knod_bpf_jit_pass_kernel(struct knod_bpf_priv *priv)
 	pass_prog.exec_save_base = KNOD_AMDGPU_EXEC_SAVE_SREG_BASE;
 	pass_prog.initial_exec_sreg = KNOD_AMDGPU_INITIAL_EXEC_SREG;
 
-	err = knod_prog_prepare_insns(priv, &pass_prog);
+	err = knod_bpf_pass_kernel_insns(priv, &pass_prog);
 	if (err)
-		return err;
-
-	/* The pass kernel ends the way every program does, so it ends with the
-	 * same code.  What it publishes it settles first: every lane counts as
-	 * having finished, and what they finished with is PASS.
-	 */
-	meta = knod_prog_pre_last_meta(&pass_prog);
-	knod_emit(priv, meta, s_mov_b64, pass_prog.done_mask_sreg,
-		  pass_prog.initial_exec_sreg);
-	knod_vset32(&p[0], KNOD_AMDGPU_VREG0_LO);
-	knod_iset32(&p[1], XDP_PASS);
-	knod_emit(priv, meta, v_mov_b32_e32, p[0], p[1]);
-
-	err = knod_bpf_emit_epilogue(priv, &pass_prog, false);
-	if (err)
-		goto free_pro;
+		goto free_all;
 
 	/* Linearize prologue + epilogue into pass_prog_buf */
 	lists[0] = &pass_prog.pre_insns;
@@ -1264,7 +1294,7 @@ static int knod_bpf_jit_pass_kernel(struct knod_bpf_priv *priv)
 	/* Remember which slot now holds pass so detach can flip back to it. */
 	priv->pass_idx = priv->active_idx;
 
-	pr_info("knod_bpf: pass kernel JIT'd %u bytes\n", priv->pass_prog_size);
+	pr_info("knod_bpf: pass kernel %u bytes\n", priv->pass_prog_size);
 	err = 0;
 	/* Retain the IR (moves the lists out) before the cleanup below
 	 * frees.

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -1242,6 +1242,8 @@ static int knod_bpf_jit_pass_kernel(struct knod_bpf_priv *priv)
 	}
 
 	kfree(priv->pass_prog_buf);
+	priv->pass_prog_buf = NULL;
+	priv->pass_prog_size = 0;
 	buf = kzalloc(total, GFP_KERNEL);
 	if (!buf) {
 		err = -ENOMEM;

--- a/include/uapi/linux/knod_blob.h
+++ b/include/uapi/linux/knod_blob.h
@@ -64,6 +64,10 @@ enum knod_blob_kind {
 	 * where the prefetcher may reach, and that is all it does.
 	 */
 	KNOD_BLOB_DEFAULT_KERNEL,
+	/* Also whole rather than spliced: prologue, a fixed XDP_PASS, epilogue.
+	 * What the BPF feature runs with no program attached.
+	 */
+	KNOD_BLOB_PASS_KERNEL,
 	KNOD_BLOB_KIND_MAX,
 };
 


### PR DESCRIPTION
Three commits finishing what `#14` started.

### `require the core blob for the default kernel`

With the default kernel available prebuilt there were two ways to produce it, and the hand-written one is the one that is wrong: `s_code_end` does not exist on gfx9, so the padding went out as an encoding that means something else. It has never been fetched — reading past `s_endpgm` is an RDNA behaviour — but keeping the path kept the bug.

It also could not be told apart from the blob at runtime. On gfx10 and gfx11 both produce identical bytes, so a queue coming up proved only that one of them ran, and a missing firmware file looked exactly like a working one.

**This makes `knod-core-gfx<N>.bin` a requirement for bringing up a queue at all**, including `feature=none`, which needs no other firmware. That is a real change in what an installed tree must carry. The JIT is unaffected — it keeps its own emission and keeps falling back to it.

### `do not leave a freed pass kernel behind on ENOMEM`

Pre-existing, found while reading the surrounding code. The old buffer is freed before the new one is allocated, so a failed allocation leaves `priv->pass_prog_buf` pointing at freed memory with the old size still recorded beside it. Both are cleared before allocating now.

### `take the whole pass kernel from the blob`

The pass kernel is a prologue, a verdict, and an epilogue, built piece by piece as though a program varied it. Nothing does. It is now one meta carrying the whole prebuilt routine; linearize, install and retain work unchanged, because a meta holding a blob is what the prologue and epilogue already were. `knod_bpf_install_kernel` never looked at the `knod_prog` it is handed, so nothing downstream wanted the register accounting that emitting it produced.

The piece-by-piece path moves into its own function and stays, for `jit_engine=0` and for blobs that predate the routine.

### Verified

Exercised on hardware (gfx10) with `TaeheeYoo/knod-blob#2` installed: pass and default both working.

Not verified: gfx9 and gfx11 silicon. Note that `knod_bpf.c:2795` refuses gfx11 outright (`XDP offload needs gfx9 or gfx10`), so the pass path is unreachable there until that gate lifts — the default kernel has no such gate.

### Depends on

`TaeheeYoo/knod-blob#2`. Blob ABI stays 3, so existing blobs keep loading; without the new one the pass kernel is emitted as before, but the **core** blob is now mandatory.

`KNOD_BLOB_ABI_VERSION` still needs resetting to 1 before upstream submission.