### PR TITLE
drm/amdkfd: knod: put a hash value where a 64-bit atomic can reach it

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -1565,9 +1565,8 @@ static int knod_bpf_map_hash_init_elem(struct knod_bpf_map *knod_map,
 	struct knod_bpf_hash_elem_obj *e;
 	int i, elem_size;
 
-	elem_size = sizeof(struct knod_bpf_hash_elem_obj) +
-			   roundup(knod_map_obj->key_size, 4) +
-			   roundup(knod_map_obj->value_size, 4);
+	elem_size = knod_bpf_hash_value_off(knod_map_obj->key_size) +
+			   roundup(knod_map_obj->value_size, 8);
 	knod_map_obj->meta.hmeta.elem_size = elem_size;
 
 	for (i = 0; i < knod_map_obj->meta.hmeta.n_buckets; i++)
@@ -1840,7 +1839,8 @@ knod_bpf_map_hash_alloc_elem(struct knod_bpf_map *knod_map,
 
 	unsafe_memcpy(knod_bpf_hash_elem_kv(e), key, knod_map_obj->key_size,
 		      "knod hash elems are variable-sized GPU map records");
-	unsafe_memcpy(knod_bpf_hash_elem_kv(e) + knod_map_obj->key_size,
+	unsafe_memcpy((unsigned char *)e +
+		      knod_bpf_hash_value_off(knod_map_obj->key_size),
 		      value, knod_map_obj->value_size,
 		      "knod hash elems are variable-sized GPU map records");
 	/* VRAM is ioremap_wc - drain new elem's next and kv stores before
@@ -1879,8 +1879,9 @@ static int knod_bpf_map_hash_lookup_elem(struct knod_bpf_map *knod_map,
 		    !memcmp(&e->kv[0], (const unsigned char *)key,
 			    knod_map_obj->key_size)) {
 			memcpy(value,
-			       (unsigned char *)&e->kv[0] +
-			       knod_map_obj->key_size,
+			       (unsigned char *)e +
+			       knod_bpf_hash_value_off(
+					knod_map_obj->key_size),
 			       knod_map_obj->value_size);
 			return 0;
 		}
@@ -1925,8 +1926,9 @@ static int knod_bpf_map_hash_update_elem(struct knod_bpf_map *knod_map,
 		if (!(e->next & KNOD_BPF_HASH_NEXT_DELETED) &&
 		    !memcmp(&e->kv[0], (const unsigned char *)key,
 			    knod_map_obj->key_size)) {
-			unsafe_memcpy(knod_bpf_hash_elem_kv(e) +
-				      knod_map_obj->key_size,
+			unsafe_memcpy((unsigned char *)e +
+				      knod_bpf_hash_value_off(
+					   knod_map_obj->key_size),
 				      value, knod_map_obj->value_size,
 				      "knod hash elems are variable-sized GPU map records");
 			return 0;
@@ -6072,8 +6074,8 @@ static void knod_bpf_map_lookup(struct knod_bpf_priv *priv,
 
 		/* bpf_reg64[0] = value address (only for matched lanes) */
 		knod_iset64(&p64[1],
-				offsetof(struct knod_bpf_hash_elem_obj, kv) +
-					 knod_map_obj_k->key_size);
+				knod_bpf_hash_value_off(
+					knod_map_obj_k->key_size));
 		knod_add64(priv, meta, bpf_reg64[0], p64[1], r64[2]);
 
 		/* set exec to unmatched lanes for next loop iteration */
@@ -6912,8 +6914,7 @@ static void knod_bpf_map_update_hash(struct knod_bpf_priv *priv,
 	}
 
 	/* Write value to new element */
-	voff = offsetof(struct knod_bpf_hash_elem_obj, kv) +
-	       knod_map_obj_k->key_size;
+	voff = knod_bpf_hash_value_off(knod_map_obj_k->key_size);
 
 	val_off = 0;
 	val_len = knod_map_obj_k->value_size;

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
@@ -7,6 +7,7 @@
 #define KFD_BPF_H_INCLUDED
 
 #include <linux/align.h>
+#include <linux/math.h>
 #include <uapi/linux/bpf.h>
 #include <net/xdp.h>
 #include <net/netmem.h>
@@ -117,10 +118,20 @@ struct knod_bpf_subparam_obj {
 #define KNOD_BPF_HASH_NEXT_DELETED	0x80000000U
 #define KNOD_BPF_HASH_NEXT_MASK		0x7FFFFFFFU
 
+/* Key and value are both 8-byte aligned so an atomic can land on either.
+ * The padding is in the published offsets rather than here, because a key's
+ * size is only known at runtime and the prebuilt routines are assembled
+ * against those offsets.
+ */
 struct knod_bpf_hash_elem_obj {
 	unsigned int next;
-	unsigned char kv[];
+	unsigned char kv[] __aligned(KNOD_BLOB_ELEM_KV_OFF);
 };
+
+static inline unsigned int knod_bpf_hash_value_off(unsigned int key_size)
+{
+	return KNOD_BLOB_ELEM_VALUE_OFF(DIV_ROUND_UP(key_size, 4));
+}
 
 struct knod_bpf_map_hash_meta_obj {
 	unsigned int n_buckets;
@@ -153,10 +164,10 @@ struct knod_bpf_map_obj {
 	unsigned int map_flags;
 	union knod_bpf_map_meta_obj meta;
 	int mutex;
-	/* A 64-bit atomic faults unless its address is 8-byte aligned (RDNA3
-	 * ISA 9.4.2), and the per-CPU counters a program updates here are
-	 * 64-bit.  What precedes leaves this on a 4-byte boundary, so say
-	 * where it has to start rather than leaving it to the fields above.
+	/* Per-CPU counters live here and a program updates them with a
+	 * 64-bit atomic, which faults on RDNA3 unless 8-byte aligned.
+	 * "RDNA3" ISA 3.3.3:
+	 * https://docs.amd.com/v/u/en-US/rdna3-shader-instruction-set-architecture-feb-2023_0
 	 */
 	unsigned char bucket[] __aligned(8);
 };

--- a/include/uapi/linux/knod_blob.h
+++ b/include/uapi/linux/knod_blob.h
@@ -19,7 +19,7 @@
 #include <linux/types.h>
 
 #define KNOD_BLOB_MAGIC		0x4b4e4442	/* 'KNDB' */
-#define KNOD_BLOB_ABI_VERSION	3
+#define KNOD_BLOB_ABI_VERSION	4
 
 /*
  * How a routine is reached.  SPLICE is what the JIT does: the bytes are copied
@@ -91,6 +91,17 @@ enum knod_blob_kind {
  * the same limit the JIT enforces as MAX_MAP_KEY_SIZE.
  */
 #define KNOD_BLOB_KEY_CHUNKS_MAX	14
+
+/*
+ * Where a hash element keeps its key and its value, both padded to eight
+ * bytes: RDNA3 faults on a misaligned atomic and a program may update a value
+ * with one.  Here rather than in the descriptor because a routine is
+ * assembled against these as immediate offsets.  "RDNA3" ISA 3.3.3:
+ * https://docs.amd.com/v/u/en-US/rdna3-shader-instruction-set-architecture-feb-2023_0
+ */
+#define KNOD_BLOB_ELEM_KV_OFF		8
+#define KNOD_BLOB_ELEM_VALUE_OFF(key_chunks)				\
+	(KNOD_BLOB_ELEM_KV_OFF + (((key_chunks) * 4 + 7) & ~7))
 
 /*
  * Register binding, splice linkage.


### PR DESCRIPTION
The per-CPU counters were fixed for this in #18; hash values were not.

An element is a four-byte next pointer, then the key padded to four, then the value — so an eight-byte key puts the value four bytes off, and a program that updates it atomically faults on RDNA3 the same way the counters did.

Nothing does today, which is why it has not been seen. The fix is cheap and the fault it prevents is a memory violation with no clue in it, so it is not worth waiting for a program that trips it.

### Three descriptions of one thing

Where the value sits was written down in three places and agreed by luck:

| | |
|---|---|
| driver, reading | `kv[0] + key_size` |
| driver, sizing | `roundup(key, 4)` |
| the prebuilt routine, in another repo | hardcoded `4`, then `key_chunks * 4` |

Nothing would have noticed one of them moving. All three now come from `KNOD_BLOB_ELEM_VALUE_OFF`, in the header both sides already share, and six call sites in the driver go through one helper.

Elements grow by four bytes for keys that were a multiple of eight. That is what the alignment costs; putting the value first would spend the same padding on the other side of the key.

### Verified

kondor on gfx11, with the matching blob installed — the connection table still resolves, so the layout move did not break lookup.

### Depends on

`TaeheeYoo/knod-blob#5`, which moves the routine onto the same macro and takes the blob ABI to 4. A routine assembled before this reads the value four bytes early, which no loader can detect, so the version has to refuse it. Every blob needs reinstalling.

### Reference

["RDNA3" ISA 3.3.3](https://docs.amd.com/v/u/en-US/rdna3-shader-instruction-set-architecture-feb-2023_0): *Atomics must be aligned to the data size, or triggers a MEMVIOL... 64-bit atomics to an 8-byte address.*

`KNOD_BLOB_ABI_VERSION` still needs resetting to 1 before upstream submission.