### PR TITLE
drm/amdkfd: knod: look a map up with a prebuilt routine

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -274,6 +274,25 @@ static_assert(sizeof(struct knod_bpf_subparam_obj) ==
  * lands at s15 and TMP_SREG0_LO stays at s16 (keeps 64-bit SGPR pair
  * alignment; avoids shifting the entire TMP/PARAM/FRAME layout).
  */
+/*+-------+-------+-------+-------+-------+-------+-----+-----+
+ *| s0-s3 | s4-s5 | s6-s7 | s8-s9 |s10-s11|s12-s13| s14 | s15 |
+ *+-------+-------+-------+-------+-------+-------+-----+-----+
+ *|  PSB  | DISP  | QUEUE | KARG  |DISP_ID|FLATSCR| WGX | WGY |
+ *+-------+-------+-------+-------+-------+-------+-----+-----+
+ * The hardware loads these from the dispatch packet before the wave starts,
+ * so nothing may be assigned there.  WGY doubles as the queue id.
+ *
+ *+---------+---------+---------+---------+---------+---------+---------+---------+---------+
+ *| s16-s27 | s28-s29 | s30-s31 | s32-s33 | s34-s35 | s36-s47 | s48-s51 | s52-s99 |s100-s101|
+ *+---------+---------+---------+---------+---------+---------+---------+---------+---------+
+ *| TMP 0-5 |  PARAM  | FP/DESC | unused  |DONE MASK|BLOB XSAV|BLOB TMP |EXEC SAVE|INIT EXEC|
+ *+---------+---------+---------+---------+---------+---------+---------+---------+---------+
+ * TMP holds nothing across a BPF instruction.  DONE MASK and INIT EXEC hold
+ * theirs across the whole program, and EXEC SAVE across whichever BPF-level
+ * scope was given the pair - so a spliced routine gets a window of its own
+ * rather than any of those.  FP is written once in the prologue and never
+ * read; s[30:31] carries the map descriptor into a routine.
+ */
 #define KNOD_AMDGPU_PSB_SREG		0  /* s[0:3] private_segment_buffer */
 #define KNOD_AMDGPU_DISPATCH_PTR_SREG	4  /* s[4:5] dispatch_ptr */
 #define KNOD_AMDGPU_ARG_SREG		4  /* alias for dispatch_ptr */
@@ -317,7 +336,11 @@ static_assert(sizeof(struct knod_bpf_subparam_obj) ==
 
 /* s[34:35] - must not overlap TMP_SREGs */
 #define KNOD_AMDGPU_DONE_MASK_SREG	34
-#define KNOD_AMDGPU_EXEC_SAVE_SREG_BASE 36 /* s[36:37], s[38:39], ... */
+/* s36-s51 belongs to whatever routine is spliced in: its own EXEC saves and
+ * its scratch scalars.  A BPF-level scope cannot be given one of those,
+ * because a splice inside the scope would overwrite it.
+ */
+#define KNOD_AMDGPU_EXEC_SAVE_SREG_BASE	(KNOD_BLOB_SPLICE_TMP_SREG_END + 1)
 #define KNOD_AMDGPU_EXEC_SAVE_SREG_MAX	99
 #define KNOD_AMDGPU_INITIAL_EXEC_SREG	100 /* in-bounds EXEC snapshot */
 #define KNOD_AMDGPU_MAX_EXEC_SAVE_PAIRS					\
@@ -9091,7 +9114,7 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 	 */
 	meta = knod_prog_pre_last_meta(knod_prog);
 
-	for (sreg = KNOD_AMDGPU_EXEC_SAVE_SREG_BASE;
+	for (sreg = KNOD_BLOB_EXEC_SAVE_SREG;
 	     sreg < KNOD_AMDGPU_EXEC_SAVE_SREG_MAX;
 	     sreg += 2)
 		knod_emit(priv, meta, s_mov_b64, sreg,

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -1626,6 +1626,45 @@ knod_bpf_array_value_ptr(struct knod_bpf_map_obj *knod_map_obj,
 	       (size_t)idx * knod_map_obj->value_size;
 }
 
+/* Restate the map for a prebuilt routine, which knows this layout and none of
+ * the kernel's own.  Everything a routine can reach is an offset from here, so
+ * a blob carries no relocations.
+ */
+static void knod_bpf_map_fill_desc(struct knod_bpf_map *knod_map)
+{
+	const struct knod_bpf_map_obj *obj = knod_map->knod_map_obj;
+	struct knod_blob_map_desc *desc = knod_map->desc;
+	u64 obj_gaddr = knod_map->mem->gaddr;
+
+	memset(desc, 0, sizeof(*desc));
+	desc->key_size = obj->key_size;
+	desc->value_size = obj->value_size;
+	desc->max_entries = obj->max_entries;
+	desc->bucket_gaddr = obj_gaddr +
+			     offsetof(struct knod_bpf_map_obj, bucket);
+	/* Where the values are, whatever kind of map this is.  An array keeps
+	 * them in the map object itself and a hash in a BO of its own, and a
+	 * routine is told the base rather than the difference.
+	 */
+	desc->elems_gaddr = desc->bucket_gaddr;
+
+	if (obj->map_type == BPF_MAP_TYPE_HASH) {
+		desc->elem_size = obj->meta.hmeta.elem_size;
+		desc->elems_gaddr = (u64)obj->meta.hmeta.elems;
+		desc->queue_gaddr = (u64)obj->meta.hmeta.q;
+		desc->gc_list_gaddr = (u64)obj->meta.hmeta.gc_list;
+		desc->gc_count_gaddr = obj_gaddr +
+			offsetof(struct knod_bpf_map_obj, meta.hmeta.gc_count);
+		desc->n_buckets = obj->meta.hmeta.n_buckets;
+		/* The locks follow the bucket heads in the same array. */
+		desc->lock_offset = obj->meta.hmeta.n_buckets *
+				    sizeof(unsigned int);
+		desc->hashrnd = obj->meta.hmeta.hashrnd;
+	} else {
+		desc->per_instance_size = obj->meta.ameta.per_instance_size;
+	}
+}
+
 static int __knod_bpf_map_alloc(struct knod_dev *knodev,
 				struct bpf_offloaded_map *offmap)
 {
@@ -1641,7 +1680,7 @@ static int __knod_bpf_map_alloc(struct knod_dev *knodev,
 	struct knod_bpf_map_obj *knod_map_obj;
 	struct knod *knod = priv->knod;
 	struct knod_bpf_map *knod_map;
-	unsigned int gc_size;
+	unsigned int gc_size, desc_off;
 	unsigned int *q;
 
 	if (offmap->map.map_type == BPF_MAP_TYPE_HASH) {
@@ -1674,6 +1713,8 @@ static int __knod_bpf_map_alloc(struct knod_dev *knodev,
 	       (value_size * nents * n_instances);
 	if (offmap->map.map_type == BPF_MAP_TYPE_HASH)
 		size += sizeof(unsigned int) * nents;
+	desc_off = round_up(size, __alignof__(struct knod_blob_map_desc));
+	size = desc_off + sizeof(struct knod_blob_map_desc);
 	order = get_order(size);
 
 	mem = knod_alloc_mem(knod, PAGE_SIZE << order, flags);
@@ -1695,6 +1736,9 @@ static int __knod_bpf_map_alloc(struct knod_dev *knodev,
 	if (offmap->dev_priv)
 		WARN_ON_ONCE(1);
 	offmap->dev_priv = knod_map;
+
+	knod_map->desc = mem->kaddr + desc_off;
+	knod_map->desc_gaddr = mem->gaddr + desc_off;
 
 	knod_map_obj = (struct knod_bpf_map_obj *)mem->kaddr;
 	knod_map_obj->key_size = offmap->map.key_size;
@@ -1772,6 +1816,8 @@ static int __knod_bpf_map_alloc(struct knod_dev *knodev,
 		knod_map_obj->meta.hmeta.gc_count = 0;
 		knod_map_obj->meta.hmeta.gc_list = (void *)gc_mem->gaddr;
 	}
+
+	knod_bpf_map_fill_desc(knod_map);
 
 	err = __knod_map_mem(knod, mem);
 	if (err) {

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -1565,8 +1565,8 @@ static int knod_bpf_map_hash_init_elem(struct knod_bpf_map *knod_map,
 	struct knod_bpf_hash_elem_obj *e;
 	int i, elem_size;
 
-	elem_size = knod_bpf_hash_value_off(knod_map_obj->key_size) +
-			   roundup(knod_map_obj->value_size, 8);
+	elem_size = knod_bpf_hash_elem_size(knod_map_obj->key_size,
+					    knod_map_obj->value_size);
 	knod_map_obj->meta.hmeta.elem_size = elem_size;
 
 	for (i = 0; i < knod_map_obj->meta.hmeta.n_buckets; i++)
@@ -1709,10 +1709,9 @@ static int __knod_bpf_map_alloc(struct knod_dev *knodev,
 		knod_map->queue_mem = queue_mem;
 		knod_map_obj->meta.hmeta.q = (struct _queue *)queue_mem->gaddr;
 
-		queue_size = (sizeof(struct knod_bpf_hash_elem_obj) +
-			      roundup(knod_map_obj->key_size, 4) +
-			      roundup(knod_map_obj->value_size, 4)) *
-			      knod_map_obj->max_entries;
+		queue_size = knod_bpf_hash_elem_size(knod_map_obj->key_size,
+						     knod_map_obj->value_size) *
+			     knod_map_obj->max_entries;
 		queue_size = PAGE_SIZE << get_order(queue_size);
 
 		hash_elems_mem = knod_alloc_mem(knod, queue_size, flags);

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -1164,8 +1164,8 @@ static struct knod_insn_meta *knod_bpf_pad_shader(struct knod_bpf_priv *priv,
 	return meta;
 }
 
-/* Bytes a meta puts in the program: a spliced routine, then anything emitted
- * after it.  Everything that walks the metas to work out where something sits
+/* Bytes a meta puts in the program: everything it emitted, plus a spliced
+ * routine.  Everything that walks the metas to work out where something sits
  * goes through here, because a routine the JIT did not emit still takes up
  * room and a branch that ignored it would land short.
  */
@@ -1185,19 +1185,25 @@ static u8 *knod_meta_write(const struct knod_insn_meta *meta, u8 *ptr,
 			   bool trace)
 {
 	const u32 *dw;
+	u32 size;
 	u32 i;
 
-	if (meta->blob_size) {
-		memcpy(ptr, meta->blob, meta->blob_size);
-		if (trace)
-			knod_jit_dbg(" 0x%.8X\t<%u bytes spliced>\n",
-				     meta->amdgpu_insn_idx, meta->blob_size);
-		ptr += meta->blob_size;
-	}
+	/* One past the last, so a routine spliced after everything emitted -
+	 * or into a meta that emitted nothing at all - still gets written.
+	 */
+	for (i = 0; i <= meta->amdgpu_insns; i++) {
+		if (meta->blob_size && i == meta->blob_at) {
+			memcpy(ptr, meta->blob, meta->blob_size);
+			if (trace)
+				knod_jit_dbg(" 0x%.8X\t<%u bytes spliced>\n",
+					     meta->amdgpu_insn_idx,
+					     meta->blob_size);
+			ptr += meta->blob_size;
+		}
+		if (i == meta->amdgpu_insns)
+			break;
 
-	for (i = 0; i < meta->amdgpu_insns; i++) {
-		u32 size = meta->amdgpu_insn[i].size;
-
+		size = meta->amdgpu_insn[i].size;
 		dw = (const u32 *)&meta->amdgpu_insn[i];
 		memcpy(ptr, dw, size);
 		ptr += size;
@@ -5218,8 +5224,8 @@ static int knod_bpf_get_amdgpu_insn_idx(struct knod_bpf_priv *priv,
 {
 	int i, insn_idx = meta->amdgpu_insn_idx;
 
-	/* Whatever was spliced in comes before anything emitted here. */
-	insn_idx += meta->blob_size / 4;
+	if (t >= (int)meta->blob_at)
+		insn_idx += meta->blob_size / 4;
 	for (i = 0; i < t; i++)
 		insn_idx += meta->amdgpu_insn[i].size / 4;
 
@@ -9156,6 +9162,14 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 
 		meta->amdgpu_insn_idx = insn_idx;
 		meta->amdgpu_insns = 0;
+		/* Rewinding the cursor has to rewind the splice with it, or a
+		 * second translation of the same metas keeps a routine from
+		 * the first and puts it at an offset that no longer means
+		 * anything.
+		 */
+		meta->blob = NULL;
+		meta->blob_size = 0;
+		meta->blob_at = 0;
 
 		/* Structurized CFG: restore EXEC at merge points */
 		if (meta->is_merge_point) {
@@ -11205,18 +11219,25 @@ static inline int bpf_debugfs_insn(struct knod_insn_meta *meta,
 static int bpf_debugfs_dwords(struct knod_insn_meta *meta, struct seq_file *m,
 			      int *col)
 {
+	const u32 *dw;
 	int n = 0, i, j;
 
-	for (i = 0; i < (int)(meta->blob_size / 4); i++) {
-		seq_printf(m, "%08x%c", meta->blob[i],
-			   ++(*col) % 8 ? ' ' : '\n');
-		*col %= 8;
-		n++;
-	}
+	/* Same order knod_meta_write puts them in, or the dump describes a
+	 * program that was never built.
+	 */
+	for (i = 0; i <= (int)meta->amdgpu_insns; i++) {
+		if (meta->blob_size && i == (int)meta->blob_at) {
+			for (j = 0; j < (int)(meta->blob_size / 4); j++) {
+				seq_printf(m, "%08x%c", meta->blob[j],
+					   ++(*col) % 8 ? ' ' : '\n');
+				*col %= 8;
+				n++;
+			}
+		}
+		if (i == (int)meta->amdgpu_insns)
+			break;
 
-	for (i = 0; i < meta->amdgpu_insns; i++) {
-		const u32 *dw = (const u32 *)&meta->amdgpu_insn[i];
-
+		dw = (const u32 *)&meta->amdgpu_insn[i];
 		for (j = 0; j < (int)(meta->amdgpu_insn[i].size / 4); j++) {
 			seq_printf(m, "%08x%c", dw[j],
 				   ++(*col) % 8 ? ' ' : '\n');
@@ -11226,6 +11247,22 @@ static int bpf_debugfs_dwords(struct knod_insn_meta *meta, struct seq_file *m,
 	}
 
 	return n * 4;
+}
+
+/* A spliced routine in the annotated stream, one dword per line so the offsets
+ * stay right.  Undecoded: the JIT did not build it and has no more idea what is
+ * in it than the reader does.  Returns how many bytes it covered.
+ */
+static int bpf_debugfs_spliced(struct knod_insn_meta *meta, struct seq_file *m,
+			       int offset)
+{
+	u32 i;
+
+	for (i = 0; i < meta->blob_size / 4; i++)
+		seq_printf(m, "%d:\t%08x%*s ; spliced\n", offset + i * 4,
+			   meta->blob[i], KNOD_BPF_TAG_COLUMN - 16, "");
+
+	return meta->blob_size;
 }
 
 /*
@@ -11321,6 +11358,11 @@ static int bpf_insn_show(struct seq_file *m, void *v)
 		return 0;
 
 	knod_seq_dump_header(m, priv->knod, "BPF kernel", "annotated", 0, 0, 64);
+	/* Which of the two builds this is.  Otherwise the only way to tell a
+	 * dump apart is to recognise a routine in it, and the pieces the two
+	 * engines share are byte for byte the same.
+	 */
+	seq_printf(m, "# jit_engine %d\n", knod_bpf_jit_engine);
 
 	/*
 	 * Show the kernel the GPU actually dispatches: the XDP prog when one is
@@ -11367,9 +11409,18 @@ static int bpf_insn_show(struct seq_file *m, void *v)
 			scnprintf(tag, sizeof(tag), "bpf#%d",
 				  meta->bpf_insn_idx);
 
-		for (i = 0; i < meta->amdgpu_insns; i++)
+		/* Same walk knod_meta_write does, or the offsets drift from
+		 * the program at the first routine spliced into the body.
+		 */
+		for (i = 0; i <= (int)meta->amdgpu_insns; i++) {
+			if (meta->blob_size && i == (int)meta->blob_at)
+				insn_idx += bpf_debugfs_spliced(meta, m,
+								insn_idx);
+			if (i == (int)meta->amdgpu_insns)
+				break;
 			insn_idx += bpf_debugfs_insn_tagged(meta, m, i,
 							    insn_idx, tag);
+		}
 	}
 
 	/* Dwords, for the same reason as the prologue: part of this may have

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -5219,6 +5219,24 @@ static u64 knod_bpf_map_gaddr(struct knod_bpf_priv *priv, int id)
 	return 0;
 }
 
+static struct knod_bpf_map *knod_bpf_map_find(struct knod_bpf_priv *priv,
+					      int id)
+{
+	struct knod_dev *knodev = priv->knodev;
+	struct knod_bpf_map *knod_map;
+
+	mutex_lock(&knodev->lock);
+	list_for_each_entry(knod_map, &knodev->accel->xdp.bound_maps, list) {
+		if (knod_map->offmap->map.id == id) {
+			mutex_unlock(&knodev->lock);
+			return knod_map;
+		}
+	}
+	mutex_unlock(&knodev->lock);
+
+	return NULL;
+}
+
 static void *knod_bpf_map_kaddr(struct knod_bpf_priv *priv, int id)
 {
 	struct knod_dev *knodev = priv->knodev;
@@ -5793,11 +5811,85 @@ static void knod_bpf_ktime_get_ns(struct knod_bpf_priv *priv,
 	knod_mov32(priv, meta, bpf_reg64[0].hi, p[0]);
 }
 
+/* The key ends up where a routine wants it without being moved there: the
+ * JIT's fourth temporary pair is the base of the routine's scratch window.
+ */
+static_assert(KNOD_AMDGPU_TMP_VREG0_LO + KEY_IN_PKT_64 * 2 ==
+	      KNOD_BLOB_SPLICE_KEY_VREG);
+
+/* Hand the lookup to a prebuilt routine if there is one for this map.  All the
+ * JIT puts around it is the arguments and taking the result back into r0; how
+ * the map is searched stops being its business.
+ */
+static bool knod_bpf_map_lookup_blob(struct knod_bpf_priv *priv,
+				     struct knod_insn_meta *meta,
+				     struct knod_bpf_map *knod_map)
+{
+	const struct knod_bpf_map_obj *obj = knod_map->knod_map_obj;
+	int len = obj->key_size, off = meta->kreg.stack_off;
+	struct amdgcn_param32 p32[2];
+	struct amdgcn_param64 ret;
+	u32 kind, chunks, size;
+	const u32 *code;
+	int reg, n;
+
+	/* A meta holds one spliced routine, because it records one place to
+	 * put it.  One BPF call is one meta, so this should not come up.
+	 */
+	if (WARN_ON_ONCE(meta->blob))
+		return false;
+
+	switch (obj->map_type) {
+	case BPF_MAP_TYPE_ARRAY:
+		kind = KNOD_BLOB_LOOKUP_ARRAY;
+		chunks = 0;
+		break;
+	case BPF_MAP_TYPE_HASH:
+		kind = KNOD_BLOB_LOOKUP_HASH;
+		chunks = DIV_ROUND_UP(obj->key_size, 4);
+		break;
+	default:
+		return false;
+	}
+
+	code = knod_blob_find(&priv->blob, kind, chunks, &size);
+	if (!code) {
+		pr_warn_once("knod_bpf: no prebuilt lookup for kind %u key_chunks %u; emitting it\n",
+			     kind, chunks);
+		return false;
+	}
+
+	for (reg = KEY_IN_PKT_64; len > 0; reg++) {
+		n = min_t(int, len, sizeof(unsigned long));
+		knod_bpf_load_size(priv, meta, &r64[reg], &stack[0], n,
+				   512 + off);
+		off += n;
+		len -= n;
+	}
+
+	knod_sset32(&p32[0], KNOD_BLOB_SPLICE_DESC_SREG);
+	knod_iset32(&p32[1], knod_map->desc_gaddr & ~0U);
+	knod_emit(priv, meta, s_mov_b32, p32[0], p32[1]);
+	knod_sset32(&p32[0], KNOD_BLOB_SPLICE_DESC_SREG + 1);
+	knod_iset32(&p32[1], knod_map->desc_gaddr >> 32);
+	knod_emit(priv, meta, s_mov_b32, p32[0], p32[1]);
+
+	meta->blob = code;
+	meta->blob_size = size;
+	meta->blob_at = meta->amdgpu_insns;
+
+	knod_vset64(&ret, KNOD_BLOB_SPLICE_RET_VREG);
+	knod_mov64(priv, meta, bpf_reg64[0], ret);
+
+	return true;
+}
+
 static void knod_bpf_map_lookup(struct knod_bpf_priv *priv,
 			       struct knod_insn_meta *meta,
 			       int map_id)
 {
 	struct knod_bpf_map_obj *knod_map_obj_k, *knod_map_obj_g;
+	struct knod_bpf_map *knod_map;
 	int off, len, _len, idx, key_in_pkt, key_in_map;
 	bool first_cmp;
 	struct amdgcn_branch_fixup fixups[12] = {0,};
@@ -5818,6 +5910,11 @@ static void knod_bpf_map_lookup(struct knod_bpf_priv *priv,
 	knod_jit_dbg(" stack_off = %d map_id = %d\n", stack_off, map_id);
 	if (!knod_map_obj_g || !knod_map_obj_k)
 		WARN_ON_ONCE(1);
+
+	knod_map = knod_bpf_map_find(priv, map_id);
+	if (knod_bpf_jit_engine && knod_map &&
+	    knod_bpf_map_lookup_blob(priv, meta, knod_map))
+		return;
 
 	knod_bpf_load_size(priv, meta,
 			       &r64[2],

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
@@ -183,6 +183,12 @@ struct knod_bpf_map {
 	struct knod_mem *mem, *queue_mem, *hash_elems_mem, *gc_mem;
 	/* ptr to mem_k->kaddr */
 	struct knod_bpf_map_obj *knod_map_obj;
+	/* What a prebuilt routine is told about this map, at the end of the
+	 * same BO.  It restates what is above in a layout a blob can read
+	 * without knowing any of the kernel's own types.
+	 */
+	struct knod_blob_map_desc *desc;
+	u64 desc_gaddr;
 	struct bpf_offloaded_map *offmap;
 	struct knod_bpf_priv *priv;
 };

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
@@ -133,6 +133,12 @@ static inline unsigned int knod_bpf_hash_value_off(unsigned int key_size)
 	return KNOD_BLOB_ELEM_VALUE_OFF(DIV_ROUND_UP(key_size, 4));
 }
 
+static inline unsigned int knod_bpf_hash_elem_size(unsigned int key_size,
+						   unsigned int value_size)
+{
+	return knod_bpf_hash_value_off(key_size) + roundup(value_size, 8);
+}
+
 struct knod_bpf_map_hash_meta_obj {
 	unsigned int n_buckets;
 	unsigned int hashrnd;

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
@@ -264,11 +264,6 @@ struct knod_insn_meta {
 	struct bpf_insn insn;
 	short bpf_insn_idx;
 
-	/* A routine spliced in whole, before anything emitted below.  The JIT
-	 * does not look inside it: it only has to know how many bytes it added,
-	 * because the offsets every branch is resolved against are counted from
-	 * the front of the program.
-	 */
 	/* Set on the store of a percpu read-modify-write, pointing at the add
 	 * that gave the amount, so the store can be emitted as one atomic.
 	 * @percpu_rmw_swapped says the add found the map's value in its source
@@ -281,8 +276,18 @@ struct knod_insn_meta {
 	 */
 	bool percpu_rmw_uniform;
 
+	/* A routine spliced in whole.  The JIT does not look inside it: it only
+	 * has to know how many bytes it added, because the offsets every branch
+	 * is resolved against are counted from the front of the program.
+	 *
+	 * @blob_at is which emitted instruction it goes in front of, so a
+	 * routine that needs its arguments set up first can have them emitted
+	 * into the same meta.  Zero puts it at the front, which is where the
+	 * prologue and the epilogue want it.
+	 */
 	const u32 *blob;
 	u32 blob_size;
+	u32 blob_at;
 
 	struct amdgcn_insn amdgpu_insn[KNOD_META_INSNS];
 	u32 amdgpu_insn_idx;

--- a/include/uapi/linux/knod_blob.h
+++ b/include/uapi/linux/knod_blob.h
@@ -19,7 +19,7 @@
 #include <linux/types.h>
 
 #define KNOD_BLOB_MAGIC		0x4b4e4442	/* 'KNDB' */
-#define KNOD_BLOB_ABI_VERSION	5
+#define KNOD_BLOB_ABI_VERSION	6
 
 /*
  * How a routine is reached.  SPLICE is what the JIT does: the bytes are copied
@@ -28,13 +28,15 @@
  * copy through s_swappc_b64, which would let routines be compiled from C
  * rather than written in assembly, at the cost of the JIT having to spill
  * around a calling convention.  Only the register binding differs.
+ *
+ * Macros rather than an enum because the assembly selects on these, and a name
+ * the preprocessor cannot see is not an error to it - it is zero, which is a
+ * value one of these has.
  */
-#ifndef __ASSEMBLY__
+#define KNOD_BLOB_LINK_SPLICE	0
+#define KNOD_BLOB_LINK_CALL	1
 
-enum knod_blob_link {
-	KNOD_BLOB_LINK_SPLICE = 0,
-	KNOD_BLOB_LINK_CALL = 1,
-};
+#ifndef __ASSEMBLY__
 
 /*
  * Which routine an entry holds.  Array maps index straight into storage, so
@@ -156,13 +158,20 @@ enum knod_blob_kind {
 #define KNOD_BLOB_CALL_RET_ADDR_SREG	30	/* s[30:31] */
 
 /*
- * Where a routine saves EXEC.  The register numbers are baked into the
- * assembly, so unlike the pairs the JIT hands out for BPF-level scopes these
- * cannot be assigned at compile time - the JIT keeps the range free instead,
- * and an entry says through exec_save_pairs how much of it a routine uses.
+ * Where a routine saves EXEC, and the scalars it may destroy while running.
+ * The register numbers are baked into the assembly, so unlike the pairs the JIT
+ * hands out for BPF-level scopes these cannot be assigned at compile time - the
+ * JIT keeps the whole range free instead, and an entry says through
+ * exec_save_pairs how much of the first part a routine uses.
+ *
+ * Nothing below this is scratch.  In particular s[34:35] carries the mask of
+ * lanes that have reached a verdict, which is live from wherever a lane
+ * finished to the epilogue that reads it, and so across any splice.
  */
 #define KNOD_BLOB_EXEC_SAVE_SREG	36	/* s[36:37] .. s[46:47] */
 #define KNOD_BLOB_EXEC_SAVE_PAIRS_MAX	6
+#define KNOD_BLOB_SPLICE_TMP_SREG	48	/* s48-s51 clobberable */
+#define KNOD_BLOB_SPLICE_TMP_SREG_END	51
 
 /*
  * The JIT's own scalars, at the same numbers on every generation so that a

--- a/include/uapi/linux/knod_blob.h
+++ b/include/uapi/linux/knod_blob.h
@@ -19,7 +19,7 @@
 #include <linux/types.h>
 
 #define KNOD_BLOB_MAGIC		0x4b4e4442	/* 'KNDB' */
-#define KNOD_BLOB_ABI_VERSION	4
+#define KNOD_BLOB_ABI_VERSION	5
 
 /*
  * How a routine is reached.  SPLICE is what the JIT does: the bytes are copied
@@ -127,11 +127,22 @@ enum knod_blob_kind {
  * scalar load away from it.  Nothing in a blob has to be relocated.
  */
 #define KNOD_BLOB_SPLICE_DESC_SREG	30	/* s[30:31] map descriptor */
-#define KNOD_BLOB_SPLICE_KEY_VREG	22	/* v[22:23] key pointer */
 #define KNOD_BLOB_SPLICE_VAL_VREG	24	/* v[24:25] value pointer */
 #define KNOD_BLOB_SPLICE_RET_VREG	26	/* v[26:27] result, 0 if absent */
 #define KNOD_BLOB_SPLICE_TMP_VREG	28	/* v28-v59 clobberable */
 #define KNOD_BLOB_SPLICE_TMP_VREG_END	59
+
+/*
+ * The key arrives in registers, DIV_ROUND_UP(key_size, 4) of them, and not
+ * through a pointer: the JIT keeps the BPF stack in VGPRs, so a key has no
+ * address until one is made for it, and the routine wants it in registers
+ * anyway - it would only have loaded it back.
+ *
+ * They sit at the base of the scratch window, so the first chunks of that
+ * window are an input where the rest of it means nothing on entry.  The
+ * routine may destroy them once it has compared against them.
+ */
+#define KNOD_BLOB_SPLICE_KEY_VREG	KNOD_BLOB_SPLICE_TMP_VREG
 
 /*
  * Register binding, call linkage.  Matches the AMDGPU function ABI so that a

--- a/include/uapi/linux/knod_blob.h
+++ b/include/uapi/linux/knod_blob.h
@@ -232,7 +232,7 @@ struct knod_blob_map_desc {
 	__u32	max_entries;
 	__u32	elem_size;		/* hash: header + padded key + value */
 	__u64	bucket_gaddr;		/* hash: bucket heads */
-	__u64	elems_gaddr;		/* hash: element storage */
+	__u64	elems_gaddr;		/* value storage, either kind */
 	__u64	queue_gaddr;		/* hash: free-element queue */
 	__u64	gc_list_gaddr;		/* hash: deferred free list */
 	__u64	gc_count_gaddr;		/* hash: deferred free count */


### PR DESCRIPTION
Hash and array lookups now come from the blob. What the JIT puts around a
routine is the arguments and taking the result back into r0; how a map is
searched stops being its business, which is the point - it is shader code the
driver would otherwise have to carry, and carrying shader code in the kernel is
what the DRM side objects to.

Only lookups, and only the two kinds the blob has. A percpu array, and every
update and delete, still go to the emitter. Doing lookups first was meant to
prove the path with one shape of routine before six more are written against
it, and it earned that: three bugs turned up that review had not, all of them
in code that had been read but never called.

The series:

1. **Size hash element storage the way an element is sized.** Aligning the
   value to eight grew an element without growing the buffer they are cut
   from. A 4-byte key and a 4-byte value made the allocation 16 where an
   element is 24, so a thousand-entry map ran 8 KB past its BO. Page-order
   rounding hid it for small maps. Fixes the alignment patch that just landed.

2. **Keys in registers.** The contract had a routine take a pointer to the
   key. The JIT has none to give - the BPF stack lives in VGPRs - so it would
   have written the key to memory for the routine to read straight back.

3. **A register window for a routine.** The contract says s36-s47 is kept free
   for a routine's EXEC saves; it was not, and BPF scopes were handed pairs
   from s36. The routine's scratch scalars were worse: s32-s35, which includes
   the done mask, live from wherever a lane finished to the epilogue. Costs
   eight of thirty-two exec-save pairs. There is an SGPR map in the source now,
   next to the one the VGPRs have had.

4. **Splice anywhere in a meta.** A routine went in front of everything a meta
   emitted, which suits the prologue and the epilogue. A map routine wants its
   arguments set up first. The dump learned the same walk - it had been
   counting only emitted instructions, so a routine spliced into the body was
   invisible and every offset after it was wrong. That is not cosmetic: the
   dump was read as evidence that no splice had happened.

5. **A descriptor per map.** A blob cannot read `struct knod_bpf_map_obj`, so
   the map is restated in the layout the shared header publishes, at the end of
   the same BO. Every address a routine needs is an offset from there, which is
   what lets a blob carry no relocations.

6. **Use the routines.** The key needs no moving: the JIT's fourth temporary
   pair is already the base of a routine's scratch window, held there by a
   static assert.

Needs TaeheeYoo/knod-blob#6. ABI 6.

Tested on gfx1100: 45 Mpps, level with the in-kernel emitter.