### PR TITLE
drm/amdkfd: knod: guard a splice against an empty wave, and reach the free list

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -1655,6 +1655,8 @@ static void knod_bpf_map_fill_desc(struct knod_bpf_map *knod_map)
 		desc->gc_list_gaddr = (u64)obj->meta.hmeta.gc_list;
 		desc->gc_count_gaddr = obj_gaddr +
 			offsetof(struct knod_bpf_map_obj, meta.hmeta.gc_count);
+		desc->free_cur_gaddr = obj_gaddr +
+			offsetof(struct knod_bpf_map_obj, meta.hmeta.cur);
 		desc->n_buckets = obj->meta.hmeta.n_buckets;
 		/* The locks follow the bucket heads in the same array. */
 		desc->lock_offset = obj->meta.hmeta.n_buckets *
@@ -5932,6 +5934,15 @@ static bool knod_bpf_map_op_blob(struct knod_bpf_priv *priv,
 	knod_sset32(&p32[0], KNOD_BLOB_SPLICE_DESC_SREG + 1);
 	knod_iset32(&p32[1], knod_map->desc_gaddr >> 32);
 	knod_emit(priv, meta, s_mov_b32, p32[0], p32[1]);
+
+	/* Scalar instructions are not masked, so a routine entered with no live
+	 * lane still runs - and one that elects a lane with mbcnt, or spins on
+	 * a lock, does not come back out.  The contract puts this guard on the
+	 * caller; the branch clears exactly the routine.
+	 */
+	emit_s_cbranch_execz(priv->isa_version,
+			     &meta->amdgpu_insn[meta->amdgpu_insns], size / 4);
+	meta->amdgpu_insns++;
 
 	/* A routine standing in for a helper leaves its result in r0, so there
 	 * is nothing to emit after it.

--- a/include/uapi/linux/knod_blob.h
+++ b/include/uapi/linux/knod_blob.h
@@ -19,7 +19,7 @@
 #include <linux/types.h>
 
 #define KNOD_BLOB_MAGIC		0x4b4e4442	/* 'KNDB' */
-#define KNOD_BLOB_ABI_VERSION	7
+#define KNOD_BLOB_ABI_VERSION	8
 
 /*
  * How a routine is reached.  SPLICE is what the JIT does: the bytes are copied
@@ -258,6 +258,12 @@ struct knod_blob_map_desc {
 	__u32	lock_offset;		/* hash: from bucket_gaddr to the locks */
 	__u32	hashrnd;		/* hash */
 	__u32	reserved;
+	/* Index of the next element to hand out of queue_gaddr, counting down.
+	 * An insert takes one with an atomic decrement, so a routine needs the
+	 * address rather than the value.  On the end, where adding it moves no
+	 * offset a routine was already assembled against.
+	 */
+	__u64	free_cur_gaddr;		/* hash */
 };
 
 #endif /* !__ASSEMBLY__ */
@@ -278,7 +284,8 @@ struct knod_blob_map_desc {
 #define KNOD_BLOB_DESC_N_BUCKETS	64
 #define KNOD_BLOB_DESC_LOCK_OFFSET	68
 #define KNOD_BLOB_DESC_HASHRND		72
-#define KNOD_BLOB_DESC_SIZE		80
+#define KNOD_BLOB_DESC_FREE_CUR		80
+#define KNOD_BLOB_DESC_SIZE		88
 
 /*
  * What the prologue walks to reach a lane's packet, in the order it does it.


### PR DESCRIPTION
> **Merge #23 first.** This is stacked on it. Merging this one while #23 is
> still open lands it in `knod-7.3-map-array-ops` rather than `knod-7.3`, and
> then merging #23 squashes that branch as it was - which is how ABI 7 went
> missing once already.

Two things the hash writers need that the earlier routines did not.

**The descriptor gains `free_cur_gaddr`.** An insert takes an element by
decrementing the free list's index, which lives inside the kernel's own map
object where a routine cannot reach it. On the end of the descriptor, where
adding it moves no offset a routine was already assembled against. ABI 8.

**A splice is guarded with `s_cbranch_execz`,** which the contract has always
said the caller does and the caller did not. Scalar instructions are not
masked, so a routine entered with no live lane runs anyway: a lookup survived
that because it falls straight out, but one that elects a lane with `mbcnt`
elects a lane that is not there, and then spins on a lock at whatever address
that produced. A hung GPU rather than a wrong answer.

With these the blob covers all nine map operations.

### Verified on gfx1100

A live program splices seventeen routines - eight percpu array lookups, three
hash lookups, four array lookups and one `UPDATE_HASH` - and runs traffic. Every
spliced run matches the blob file byte for byte, each is preceded by a guard of
exactly the right length (17/17), and the whole 11 KB stream disassembles with
no invalid instruction and no offset discontinuity.

What that does not cover: `DELETE_HASH` never executed, and one update does not
put two lanes on one bucket, which is the only way a locking bug shows. Traffic
flowing says there is no hang; it does not say the map is right.

### The emitter stays

It has no limit on value length where a routine does, and running one program
both ways is how gfx9, gfx10 and gfx11 get compared against each other - which
has narrowed more than one bug in this series.

Needs TaeheeYoo/knod-blob#10.