### PR TITLE
selftests: drivers/net/knod: exercise hash insert, overwrite and delete

### DIFF
--- a/tools/testing/selftests/drivers/net/knod/Makefile
+++ b/tools/testing/selftests/drivers/net/knod/Makefile
@@ -4,6 +4,7 @@ TEST_PROGS := \
 	knod_xdp_ktime.sh \
 	knod_xdp_loop.sh \
 	knod_attach.sh \
+	knod_xdp_hash_ops.sh \
 # end of TEST_PROGS
 
 TEST_FILES := \

--- a/tools/testing/selftests/drivers/net/knod/knod_xdp_hash_ops.sh
+++ b/tools/testing/selftests/drivers/net/knod/knod_xdp_hash_ops.sh
@@ -1,0 +1,285 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+#
+# knod_xdp_hash_ops.sh - hash map insert, overwrite and delete on GPU XDP
+#
+# The offloaded hash writers take a per-bucket lock and then serialise the
+# lanes that share a bucket, which is the only part of the map offload that
+# can be wrong intermittently rather than always.  This drives the two shapes
+# that tell them apart:
+#
+#   contention  every packet the same length, so every lane keys the same
+#               bucket and the lock is what decides the outcome
+#   chains      a sweep of lengths, so buckets hold chains and insert has to
+#               find its way down them
+#
+# What is checked is what a broken lock breaks: a key that was inserted and
+# is not there, or a key that is there twice.  Counting values would not do
+# - a BPF read-modify-write over a looked-up pointer races between lanes by
+# construction, lock or no lock.
+#
+# Requires:
+#   - KNOD (knod + amdgpu) modules loaded
+#   - AMD GPU with KNOD support
+#   - NIC with xdpoffload support (mlx5, bnxt)
+#   - bpftool, iproute2, ping
+#   - root privileges
+#   - xdp_hash_ops.bpf.o (built by make)
+#
+# Environment:
+#   NIC=<ifname>       (required) NIC to test on
+#   REMOTE_IP=<ip>     (required) ping target; the key is the packet length,
+#                      so the test has to be the one generating traffic
+#   ACCEL_ID=<id>      (optional) GPU accel ID, auto-detected if omitted
+#
+# Exit: 0=pass, 1=fail, 4=skip
+
+set -o pipefail
+
+SELFDIR=$(dirname "$(readlink -f "$0")")
+source "$SELFDIR/lib.sh"
+
+: "${NIC:=}"
+: "${ACCEL_ID:=}"
+: "${REMOTE_IP:=}"
+
+PASS=0
+FAIL=0
+BPF_OBJ="$SELFDIR/xdp_hash_ops.bpf.o"
+
+# Lengths to sweep for the chain phase, as ping payload sizes.
+SWEEP_FIRST=64
+SWEEP_COUNT=32
+SWEEP_STEP=4
+# Payload size used for the contention phase.
+HOT_SIZE=100
+HOT_PINGS=200
+
+cleanup() {
+	if [ -n "$NIC" ]; then
+		knod_cleanup "$NIC"
+	fi
+}
+trap cleanup EXIT
+
+check_result() {
+	local desc=$1
+	local ret=$2
+
+	if [ "$ret" -eq 0 ]; then
+		knod_pass "$desc"
+		PASS=$((PASS + 1))
+	else
+		knod_fail "$desc"
+		FAIL=$((FAIL + 1))
+	fi
+}
+
+ping_size() {
+	local size=$1
+	local count=$2
+
+	ping -c "$count" -i 0.01 -W 1 -s "$size" "$REMOTE_IP" >/dev/null 2>&1
+	return 0
+}
+
+# -- prereq ------------------------------------------------------
+knod_check_prereq
+
+if [ -z "$NIC" ]; then
+	knod_skip "NIC env var not set"
+fi
+
+if [ -z "$REMOTE_IP" ]; then
+	knod_skip "REMOTE_IP env var not set (this test generates its own traffic)"
+fi
+
+if ! ip link show "$NIC" >/dev/null 2>&1; then
+	knod_skip "NIC $NIC does not exist"
+fi
+
+accel_id=$(knod_find_accel)
+if [ -z "$accel_id" ]; then
+	knod_skip "no KNOD accelerator found"
+fi
+[ -n "$ACCEL_ID" ] && accel_id="$ACCEL_ID"
+
+echo "=== KNOD XDP hash map insert/overwrite/delete test ==="
+echo "    NIC:       $NIC"
+echo "    REMOTE_IP: $REMOTE_IP"
+echo "    ACCEL_ID:  $accel_id"
+echo ""
+
+if [ ! -f "$BPF_OBJ" ]; then
+	echo "FAIL: $BPF_OBJ not found (run make first)"
+	exit 1
+fi
+
+# -- attach, select feature, load ------------------------------
+ip link set dev "$NIC" down 2>/dev/null
+knod_attach "$NIC" "$accel_id" || { echo "FAIL: attach failed"; exit 1; }
+knod_feature_select "$accel_id" bpf || knod_skip "cannot select bpf feature"
+knod_xdp_load "$NIC" "$BPF_OBJ" || { echo "FAIL: xdpoffload load failed"; exit 1; }
+
+prog_id=$(bpftool prog show 2>/dev/null | \
+	  awk '/xdp_hash_ops/ {sub(/:/, "", $1); print $1; exit}')
+if [ -z "$prog_id" ]; then
+	echo "FAIL: cannot find loaded BPF program"
+	exit 1
+fi
+
+len_map=$(knod_find_map_by_name "$prog_id" len_map)
+del_map=$(knod_find_map_by_name "$prog_id" del_map)
+stats_map=$(knod_find_map_by_name "$prog_id" stats)
+if [ -z "$len_map" ] || [ -z "$del_map" ] || [ -z "$stats_map" ]; then
+	echo "FAIL: cannot find maps (len=$len_map del=$del_map stats=$stats_map)"
+	exit 1
+fi
+knod_log "prog_id=$prog_id len_map=$len_map del_map=$del_map stats=$stats_map"
+
+ip link set dev "$NIC" up
+sleep 1
+
+# -- phase 0: learn what length the GPU sees -------------------
+#
+# A ping payload of N bytes does not arrive as N: headers, and whatever the
+# NIC does with the frame, sit between.  Rather than assume the offset, send
+# one size and read back the key it produced.
+ping_size "$HOT_SIZE" 20
+sleep 1
+
+hot_keys=$(knod_map_keys_u32 "$len_map")
+hot_key=$(echo "$hot_keys" | head -1)
+nr=$(echo "$hot_keys" | grep -c .)
+
+if [ -z "$hot_key" ] || [ "$hot_key" = "0" ]; then
+	echo "FAIL: no key appeared after traffic; is the program running?"
+	exit 1
+fi
+hdr=$((hot_key - HOT_SIZE))
+knod_log "payload $HOT_SIZE arrived as length $hot_key (header $hdr bytes)"
+
+# One length in, one key out.  More than one means the sender is not the
+# only source of traffic, and the phases below cannot be trusted.
+rc=0
+[ "$nr" -eq 1 ] || rc=1
+check_result "one length gives one key ($nr present)" $rc
+if [ "$rc" -ne 0 ]; then
+	knod_log "other traffic is reaching the NIC; run this on a quiet link"
+	echo ""
+	echo "=== Results: $PASS passed, $FAIL failed ==="
+	exit 1
+fi
+
+# -- phase 1: contention ---------------------------------------
+#
+# Every packet the same length, so every lane of every wave hashes to one
+# bucket and takes the same lock.  The element is already there after phase
+# 0, so this is the overwrite path under maximum contention.
+knod_log "contention: $HOT_PINGS packets at one length"
+ping_size "$HOT_SIZE" "$HOT_PINGS"
+sleep 1
+
+nr=$(knod_map_nr_elems "$len_map")
+rc=0
+[ "$nr" -eq 1 ] || rc=1
+check_result "overwrite under contention leaves one element ($nr)" $rc
+
+# -- phase 2: chains -------------------------------------------
+#
+# A sweep of lengths, each seen many times, so inserts and overwrites run
+# together and buckets grow chains.
+knod_log "chains: $SWEEP_COUNT lengths, 20 packets each"
+expect_keys=""
+i=0
+while [ "$i" -lt "$SWEEP_COUNT" ]; do
+	size=$((SWEEP_FIRST + i * SWEEP_STEP))
+	ping_size "$size" 20
+	expect_keys="$expect_keys $((size + hdr))"
+	i=$((i + 1))
+done
+sleep 2
+
+missing=0
+for k in $expect_keys; do
+	if ! knod_map_has_key_u32 "$len_map" "$k"; then
+		knod_log "key $k was inserted and is not there"
+		missing=$((missing + 1))
+	fi
+done
+rc=0
+[ "$missing" -eq 0 ] || rc=1
+check_result "every inserted key is present ($missing missing)" $rc
+
+# A duplicate is the other way a broken lock shows: two lanes both decide the
+# key is absent and both link an element for it.
+dups=$(knod_map_keys_u32 "$len_map" | sort | uniq -d | grep -c . )
+rc=0
+[ "$dups" -eq 0 ] || rc=1
+check_result "no key appears twice ($dups duplicated)" $rc
+
+# The hot key from phase 1 plus the sweep, and nothing else.
+nr=$(knod_map_nr_elems "$len_map")
+want=$((SWEEP_COUNT + 1))
+rc=0
+[ "$nr" -eq "$want" ] || rc=1
+check_result "element count matches keys sent ($nr, want $want)" $rc
+
+# -- phase 3: delete -------------------------------------------
+#
+# The host puts the keys in del_map; the program finds them there, writes
+# them once more and deletes them.  Anything left afterwards was not deleted.
+knod_log "delete: marking $SWEEP_COUNT keys"
+for k in $expect_keys; do
+	knod_map_update_u32_u64 "$del_map" "$k"
+done
+
+marked=$(knod_map_nr_elems "$del_map")
+rc=0
+[ "$marked" -eq "$SWEEP_COUNT" ] || rc=1
+check_result "host populated del_map ($marked, want $SWEEP_COUNT)" $rc
+
+i=0
+while [ "$i" -lt "$SWEEP_COUNT" ]; do
+	ping_size $((SWEEP_FIRST + i * SWEEP_STEP)) 10
+	i=$((i + 1))
+done
+sleep 2
+
+left=$(knod_map_nr_elems "$del_map")
+rc=0
+[ "$left" -eq 0 ] || rc=1
+check_result "every marked key was deleted ($left left)" $rc
+
+# -- phase 4: the map still works ------------------------------
+#
+# Deleted elements go to a GC list and the host hands them back on a tick.
+# If that did not happen the map is out of elements and this insert fails,
+# which is the difference between a delete that unlinked and one that leaked.
+knod_log "reuse: inserting after the deletes"
+for k in $expect_keys; do
+	knod_map_update_u32_u64 "$del_map" "$k"
+done
+sleep 1
+reused=$(knod_map_nr_elems "$del_map")
+rc=0
+[ "$reused" -eq "$SWEEP_COUNT" ] || rc=1
+check_result "deleted elements came back ($reused, want $SWEEP_COUNT)" $rc
+
+# -- packets did flow ------------------------------------------
+pkts=$(knod_map_lookup_u64 "$stats_map" 0)
+knod_log "packets seen by the program: $pkts"
+rc=0
+[ "$pkts" -gt 0 ] || rc=1
+check_result "packets processed ($pkts)" $rc
+
+ip link set dev "$NIC" down
+
+# -- summary ---------------------------------------------------
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+	exit 1
+fi
+exit 0

--- a/tools/testing/selftests/drivers/net/knod/lib.sh
+++ b/tools/testing/selftests/drivers/net/knod/lib.sh
@@ -179,3 +179,69 @@ knod_map_lookup_u64() {
 		printf "0x%x", v;
 	}')"
 }
+
+knod_get_map_ids() {
+	local prog_id=$1
+
+	bpftool prog show id "$prog_id" 2>/dev/null | \
+		grep -o 'map_ids [0-9,]*' | awk '{print $2}' | tr ',' ' '
+}
+
+# A program with more than one map needs them told apart, and the order
+# bpftool lists them in is not the order they are declared in.
+knod_find_map_by_name() {
+	local prog_id=$1
+	local name=$2
+	local id
+
+	for id in $(knod_get_map_ids "$prog_id"); do
+		if bpftool map show id "$id" 2>/dev/null | \
+		   grep -qE "(^|[[:space:]])name ${name}([[:space:]]|$)"; then
+			echo "$id"
+			return
+		fi
+	done
+}
+
+knod_map_nr_elems() {
+	local map_id=$1
+	local n
+
+	n=$(bpftool map dump id "$map_id" 2>/dev/null | \
+	    awk '/^Found/ {print $2}')
+	[ -n "$n" ] || n=0
+	echo "$n"
+}
+
+# Every key the map holds, one per line, as a decimal u32.
+knod_map_keys_u32() {
+	local map_id=$1
+
+	bpftool map dump id "$map_id" 2>/dev/null | \
+		awk '/^key:/ {
+			printf "%d\n", strtonum("0x" $5 $4 $3 $2)
+		}'
+}
+
+knod_map_has_key_u32() {
+	local map_id=$1
+	local key=$2
+	local b0=$((key & 255))
+	local b1=$(((key >> 8) & 255))
+	local b2=$(((key >> 16) & 255))
+	local b3=$(((key >> 24) & 255))
+
+	bpftool map lookup id "$map_id" key $b0 $b1 $b2 $b3 >/dev/null 2>&1
+}
+
+knod_map_update_u32_u64() {
+	local map_id=$1
+	local key=$2
+	local b0=$((key & 255))
+	local b1=$(((key >> 8) & 255))
+	local b2=$(((key >> 16) & 255))
+	local b3=$(((key >> 24) & 255))
+
+	bpftool map update id "$map_id" key $b0 $b1 $b2 $b3 \
+		value 1 0 0 0 0 0 0 0 >/dev/null 2>&1
+}

--- a/tools/testing/selftests/drivers/net/knod/xdp_hash_ops.bpf.c
+++ b/tools/testing/selftests/drivers/net/knod/xdp_hash_ops.bpf.c
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+/* The key is the packet length, so the sender decides how the lanes are
+ * spread: one length puts every lane on one bucket and stresses the lock,
+ * a sweep of lengths fills chains and stresses insert.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 1024);
+	__type(key, __u32);
+	__type(value, __u64);
+} len_map SEC(".maps");
+
+/* Lengths this program deletes rather than keeps.  Populated by the test so
+ * that which keys should be absent afterwards is the test's decision and not
+ * something it has to infer.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 1024);
+	__type(key, __u32);
+	__type(value, __u64);
+} del_map SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __u32);
+	__type(value, __u64);
+} stats SEC(".maps");
+
+SEC("xdp")
+int xdp_hash_ops(struct xdp_md *ctx)
+{
+	__u32 len = (__u32)(ctx->data_end - ctx->data);
+	__u32 zero = 0;
+	__u64 one = 1;
+	__u64 *v;
+
+	/* Insert on first sight, overwrite after.  Both paths of an update,
+	 * and with one length in flight every lane takes them on one bucket.
+	 */
+	bpf_map_update_elem(&len_map, &len, &one, BPF_ANY);
+
+	/* A length the test marked for deletion is inserted here and taken
+	 * straight back out, so delete runs against an element that is
+	 * certainly present.
+	 */
+	if (bpf_map_lookup_elem(&del_map, &len)) {
+		bpf_map_update_elem(&del_map, &len, &one, BPF_ANY);
+		bpf_map_delete_elem(&del_map, &len);
+	}
+
+	v = bpf_map_lookup_elem(&stats, &zero);
+	if (v)
+		__sync_fetch_and_add(v, 1);
+
+	return XDP_PASS;
+}
+
+char LICENSE[] SEC("license") = "GPL";


### PR DESCRIPTION
The offloaded hash writers take a per-bucket lock and then serialise the lanes
that share a bucket. That is the only part of the map offload that can be wrong
*intermittently* rather than always, and nothing tested it: the existing tests
use an array map, and the one program that reached a hash writer on hardware
did so once, from one lane.

**The key is the packet length**, so the sender decides how the lanes fall. One
length puts every lane of every wave on one bucket, which is the lock doing the
work; a sweep of lengths fills chains and makes insert walk them. Both run
against the same map, one after the other.

**What it checks is what a broken lock breaks** - a key that was inserted and is
not there, or a key that is there twice. Deliberately *not* the values: a BPF
read-modify-write over a looked-up pointer races between lanes by construction,
so a count that came out short would say nothing about the lock.

**Delete gets its own map.** The host puts the keys in, the program finds them
there and takes them out, and anything left afterwards was not deleted. A
second round of host inserts follows, because a delete that unlinked and a
delete that leaked look the same until the elements are needed again - they
come back through the GC list on a tick.

The length a payload arrives as is measured rather than assumed, and the test
stops early if more than one key appears from one length, since that means
something else is putting packets on the link and none of the later counts
would mean anything.

Phases, in order:

| | checks |
|---|---|
| calibrate | one length gives one key |
| contention | 200 packets at one length leave one element |
| chains | 32 lengths: every key present, none duplicated, count exact |
| delete | every marked key gone |
| reuse | deleted elements came back |

Needs `REMOTE_IP` - the key is the packet length, so the test has to generate
its own traffic rather than wait for ambient.

The `bpf_helper_defs.h` needed to build the BPF object comes from libbpf, so
this has been compiled against a stub of the four helpers it uses rather than
through the selftest build; it is otherwise unrun.