### PR TITLE
drm/amdkfd: knod: stop staging descriptors nothing reads, and measure a rate instead of inferring one

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -886,12 +886,12 @@ static struct knod_bpf_work_sq *knod_prepare_bpf(struct knod_bpf_priv *priv)
 	memset(sqw->queue_idx, 0, sizeof(sqw->queue_idx));
 
 	/* 2D dispatch: queue_id = workgroup_id_y, tid = workitem within WG.
-	 * Per-queue bds live in sqw->bds[i * batch_size + tid] and shader
-	 * indexes sub[] / sqw->bds[] using (queue_id * batch_size + tid).
-	 * No cumulative start_idx -- each queue's slot range is fixed by i.
+	 * The shader indexes sub[] by (queue_id * batch_size + tid) and reads
+	 * the descriptor out of the SPSC pool itself, so all that is wanted
+	 * here is how many each queue has.  No cumulative start_idx -- each
+	 * queue's slot range is fixed by i.
 	 */
 	for (i = 0; i < priv->nr_works; i++) {
-		int slot = i * priv->batch_size;
 		unsigned int skip = 0, j;
 
 		/* Stage past every in-flight dispatch's claim on this queue so
@@ -902,9 +902,8 @@ static struct knod_bpf_work_sq *knod_prepare_bpf(struct knod_bpf_priv *priv)
 			skip += priv->inflight[j]->queue_idx[i];
 
 		param->queues[i].count = 0;
-		spsc_peek_at(&knodev->wpriv[i].spsc_bds, skip,
-			     (void **)&sqw->bds[slot],
-			     priv->batch_size, &cnt);
+		spsc_peek_count(&knodev->wpriv[i].spsc_bds, skip,
+				priv->batch_size, &cnt);
 		if (!cnt) {
 			sqw->queue_idx[i] = 0;
 			param->queues[i].count = 0;
@@ -4197,8 +4196,7 @@ static int knod_prog_prepare_insns(struct knod_bpf_priv *priv,
 	knod_emit(priv, meta, v_mov_b32_e32, param[0], param[1]);
 
 	/* i. IDX_VREG = (queue_id << ilog2(batch_size)) + local_idx
-	 *    -> flat_IDX into the sub[] / sqw->bds[] arrays, matching the
-	 *    CPU-side layout `sqw->bds[queue_id * batch_size + local_idx]`.
+	 *    -> flat_IDX into sub[], which the host lays out the same way.
 	 *    batch_size is rounded down to a power of two at start so the
 	 *    shift is exact.
 	 */

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -11798,14 +11798,27 @@ static int knod_stats_show(struct seq_file *s, void *unused)
 	struct knod_bpf_priv *priv = s->private;
 	u64 p50 = 0, p99 = 0, p999 = 0, acc;
 	struct knod_bpf_stats *stats;
-	u64 ccnt, dcnt;
+	u64 ccnt, dcnt, elapsed, end, mpps;
 	int i;
 
 	stats = &priv->stats;
 	ccnt = stats->completion_count;
 	dcnt = stats->dispatch_count;
+	end = stats->stop_ns ? stats->stop_ns : ktime_get_ns();
+	elapsed = stats->start_ns ? end - stats->start_ns : 0;
+
 	seq_printf(s, "enabled:             %s\n",
 		   static_branch_unlikely(&knod_stats_key) ? "yes" : "no");
+
+	if (elapsed) {
+		mpps = stats->backlogs_total * 100000ULL / elapsed;
+		seq_printf(s, "elapsed_ms:          %llu\n",
+			   elapsed / NSEC_PER_MSEC);
+		seq_printf(s, "dispatch_per_s:      %llu\n",
+			   dcnt * NSEC_PER_SEC / elapsed);
+		seq_printf(s, "throughput:          %llu.%02llu Mpps\n",
+			   mpps / 100, mpps % 100);
+	}
 
 	seq_puts(s, "\n--- dispatch ---\n");
 	seq_printf(s, "count:               %llu\n", dcnt);
@@ -11864,15 +11877,20 @@ static ssize_t knod_stats_enable_write(struct file *file,
 				       const char __user *buf,
 				       size_t count, loff_t *ppos)
 {
+	struct knod_bpf_priv *priv = file->private_data;
 	bool val;
 
 	if (kstrtobool_from_user(buf, count, &val))
 		return -EINVAL;
 
-	if (val)
+	if (val) {
+		priv->stats.start_ns = ktime_get_ns();
+		priv->stats.stop_ns = 0;
 		static_branch_enable(&knod_stats_key);
-	else
+	} else {
 		static_branch_disable(&knod_stats_key);
+		priv->stats.stop_ns = ktime_get_ns();
+	}
 
 	return count;
 }
@@ -11892,6 +11910,7 @@ static ssize_t knod_stats_enable_read(struct file *file,
 
 static const struct file_operations knod_stats_enable_fops = {
 	.owner = THIS_MODULE,
+	.open  = simple_open,
 	.read  = knod_stats_enable_read,
 	.write = knod_stats_enable_write,
 };
@@ -11903,6 +11922,7 @@ static ssize_t knod_stats_reset_write(struct file *file,
 	struct knod_bpf_priv *priv = file->private_data;
 
 	memset(&priv->stats, 0, sizeof(priv->stats));
+	priv->stats.start_ns = ktime_get_ns();
 	return count;
 }
 

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
@@ -241,7 +241,6 @@ struct knod_bpf_work_sq {
 	struct list_head list;
 	struct knod_mem *param;
 	int queue_idx[KNOD_SPSC_MAX];
-	struct spsc_bd *bds[KNOD_BPF_BACKLOGS_MAX];
 	ktime_t dispatch_time;
 	s64 sigval;
 	unsigned long expire;

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
@@ -431,6 +431,13 @@ struct knod_prog {
 #define KNOD_BL_BUCKETS  8
 
 struct knod_bpf_stats {
+	/* The window the counters below were gathered over.  Without it a rate
+	 * can only be inferred from the completion latency and an assumed pipe
+	 * depth, which is how more than one wrong number got believed.
+	 */
+	u64 start_ns;
+	u64 stop_ns;		/* 0 while still running */
+
 	u64 dispatch_total_ns;
 	u64 dispatch_count;
 	u64 dispatch_max_ns;

--- a/include/net/spsc_ring.h
+++ b/include/net/spsc_ring.h
@@ -404,6 +404,34 @@ static inline int spsc_peek_at(struct spsc_ring *r, unsigned int skip,
 }
 
 /**
+ * spsc_peek_count - how many entries sit at @skip, without copying them out
+ * @r:    ring buffer
+ * @skip: number of entries to skip past r->acquired
+ * @max:  most to report
+ * @cnt:  out - number available, capped at @max
+ *
+ * For a consumer that reads the slots itself and only needs to know how many
+ * there are.  Moves no cursor, and self-limits the same way spsc_peek_at()
+ * does.
+ *
+ * Returns 0 on success, -ENOENT if nothing is there.
+ */
+static inline int spsc_peek_count(struct spsc_ring *r, unsigned int skip,
+				  unsigned int max, unsigned int *cnt)
+{
+	unsigned int head = smp_load_acquire(&r->head);
+	unsigned int pos = r->acquired + skip;
+
+	if ((int)(head - pos) <= 0) {
+		*cnt = 0;
+		return -ENOENT;
+	}
+
+	*cnt = min(head - pos, max);
+	return 0;
+}
+
+/**
  * spsc_acquire - advance acquired cursor (step 1)
  * @r:   ring buffer
  * @out: destination array for element pointers, or NULL to skip


### PR DESCRIPTION
Two things, one of which made the other believable.

## Staging filled an array nothing read

The shader finds a packet's descriptor itself: the queue descriptor hands it
the SPSC pool address, the ring cursor and the mask, and the prologue loads
from `pool + (((ring_start + idx) & mask) << spsc_shift)`.  It has done so
since the ring became a direct read.

Staging never stopped copying those descriptors to the host side as well.
Every dispatch walked all queues and filled `sqw->bds[]` with up to
`batch_size` pointers each, and nothing in the BPF path ever read one -
the array is written and never mentioned again.

It was not free.  It is 65536 pointers, 512 KB, and there are 32 of them, so
a run cycles a **16 MB write-only working set** through the caches the NAPI
threads are trying to use.

Measured on 22 channels, `wg=256`, `xgroups=1`, everything else held still,
25 s per run:

| | before | after |
|---|---|---|
| staging pass | 7633 ns | **562 ns** |
| throughput | 29.87 Mpps | **35.78 Mpps** |
| completion | 322.3 µs | 255.1 µs |
| backlogs/dispatch | 5570 | 5557 |

`spsc_peek_count()` reports what `spsc_peek_at()` would have counted without
copying anything - no cursor moved, same self-limiting - and the count is all
staging ever wanted from that call.  The IPsec path keeps its own descriptor
array, which it does read.

## The stats could not tell you a rate

The counters said how long a dispatch took and how many packets it carried,
but never over what stretch of time.  Throughput had to be worked out from
the completion latency and an assumed pipe depth of `KNOD_BPF_INFLIGHT`.

The pipe does not run at that depth.  Measured runs came out at 2.14, 1.73,
2.92 - never 3.  Every number derived that way was wrong, and each wrong
number retired a hypothesis that deserved better.

So: stamp the window when stats are switched on or reset, close it when they
are switched off, and print `elapsed_ms`, `dispatch_per_s` and a throughput
in Mpps straight from `backlogs_total`.  Nothing has to be assumed to read
them.  The numbers in the table above are from that output.

`stats_enable` gains `simple_open` so its write handler can reach `priv`,
which is how the window gets stamped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)