### PR TITLE
drm/amdkfd: knod: have the stats say what they were taken on

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -11810,6 +11810,18 @@ static int knod_stats_show(struct seq_file *s, void *unused)
 	seq_printf(s, "enabled:             %s\n",
 		   static_branch_unlikely(&knod_stats_key) ? "yes" : "no");
 
+	/* What the numbers below were taken on.  A dump that does not say is a
+	 * dump that gets compared against the wrong one later.
+	 */
+	seq_puts(s, "\n--- geometry ---\n");
+	seq_printf(s, "channels:            %d\n", priv->nr_works);
+	seq_printf(s, "workgroup_size:      %u\n", knod_bpf_workgroups);
+	seq_printf(s, "groups_per_queue:    %d\n",
+		   knod_bpf_workgroups ? priv->batch_size /
+		   (int)knod_bpf_workgroups : 0);
+	seq_printf(s, "batch:               %d per queue, %d total\n",
+		   priv->batch_size, priv->batch_size * priv->nr_works);
+
 	if (elapsed) {
 		mpps = stats->backlogs_total * 100000ULL / elapsed;
 		seq_printf(s, "elapsed_ms:          %llu\n",


### PR DESCRIPTION
Channel count, workgroup size and how many workgroups a queue gets are all
tunable at run time, and a dump carried none of them.  Comparing two dumps
meant remembering which knobs were where, and three times in one afternoon
that memory was wrong - a sweep read as a workgroup-size result when
`xgroups` had moved, another read as 22 channels when it was 11, a third as
`xgroups=2` when it was 4.

```
--- geometry ---
channels:            22
workgroup_size:      128
groups_per_queue:    2
batch:               256 per queue, 5632 total
```

`groups_per_queue` comes out of the batch size rather than the knob it was
asked for, so it shows what the dispatch actually used after the flat-array
cap and the power-of-two rounding.  Ask for 4 and get 2 and the dump says 2.

Follows #29, which gave the same output a measured window; this says what
that window was measured on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)