### PR TITLE
drm/amdkfd: knod: count the compute units a dispatch reaches

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -989,11 +989,54 @@ static void knod_submit_bpf(struct knod_bpf_priv *priv,
 /* Phase 1: advance SPSC consumer pointers so next dispatch can peek
  * new entries.
  */
+/* Count what ran this dispatch's packets, before the cursor moves past them.
+ * A dispatch completes oldest first, so its slots start where the ring was
+ * acquired to.
+ *
+ * Two numbers, and the second is the one worth having.  The histogram counts
+ * packets per unit over the whole run, which says only which units the device
+ * has: the hardware rotates workgroups around them, so given enough dispatches
+ * every unit shows up however few a dispatch uses at once.  The distinct count
+ * per dispatch is what says whether asking for more workgroups per queue
+ * actually reaches more units.
+ */
+static void knod_hwid_count(struct knod_bpf_priv *priv,
+			    struct knod_bpf_work_sq *sqw)
+{
+	DECLARE_BITMAP(seen, KNOD_HWID_SLOTS);
+	struct knod_dev *knodev = priv->knodev;
+	struct spsc_ring *r;
+	struct spsc_bd *bd;
+	unsigned int k, unit;
+	int i;
+
+	bitmap_zero(seen, KNOD_HWID_SLOTS);
+
+	for (i = 0; i < priv->nr_works; i++) {
+		if (sqw->queue_idx[i] < 1)
+			continue;
+
+		r = &knodev->wpriv[i].spsc_bds;
+		for (k = 0; k < sqw->queue_idx[i]; k++) {
+			bd = r->slots[(r->acquired + k) & r->mask];
+			unit = knod_hwid_unit((u32)(bd->act >> 32));
+			priv->stats.hwid_hist[unit]++;
+			__set_bit(unit, seen);
+		}
+	}
+
+	priv->stats.hwid_units_total += bitmap_weight(seen, KNOD_HWID_SLOTS);
+	priv->stats.hwid_dispatches++;
+}
+
 static void knod_complete_acquire(struct knod_bpf_priv *priv,
 				  struct knod_bpf_work_sq *sqw)
 {
 	struct knod_dev *knodev = priv->knodev;
 	int i;
+
+	if (static_branch_unlikely(&knod_stats_key))
+		knod_hwid_count(priv, sqw);
 
 	for (i = 0; i < priv->nr_works; i++) {
 		if (sqw->queue_idx[i] >= 1) {
@@ -11879,6 +11922,37 @@ static int knod_stats_show(struct seq_file *s, void *unused)
 		   stats->decode_act_count ?
 		   stats->decode_act_total_ns / stats->decode_act_count : 0);
 	seq_printf(s, "max_ns:              %llu\n", stats->decode_act_max_ns);
+
+	/* The grid asks for groups_per_queue workgroups per queue; this says how
+	 * many units they actually reached.
+	 *
+	 * A blob without the probe leaves the field it reads at zero, which
+	 * lands every packet in slot 0 and reads exactly like the answer this
+	 * was built to look for - one unit doing everything.  So say which of
+	 * the two it is rather than let the shape of the output decide.
+	 */
+	for (i = 0, acc = 0; i < KNOD_HWID_SLOTS; i++)
+		if (stats->hwid_hist[i])
+			acc++;
+
+	if (acc == 1 && stats->hwid_hist[0]) {
+		seq_puts(s, "\n--- compute units ---\n");
+		seq_puts(s, "units used:          (blob has no HW_ID probe)\n");
+	} else if (acc) {
+		seq_puts(s, "\n--- compute units ---\n");
+		seq_printf(s, "units on device:     %llu\n", acc);
+		seq_printf(s, "units per dispatch:  %llu.%02llu\n",
+			   stats->hwid_dispatches ?
+			   stats->hwid_units_total / stats->hwid_dispatches : 0,
+			   stats->hwid_dispatches ?
+			   stats->hwid_units_total * 100 /
+			   stats->hwid_dispatches % 100 : 0);
+		for (i = 0; i < KNOD_HWID_SLOTS; i++)
+			if (stats->hwid_hist[i])
+				seq_printf(s, "  se%u sa%u wgp%-2u    %llu\n",
+					   i >> 5, (i >> 4) & 1, i & 0xf,
+					   stats->hwid_hist[i]);
+	}
 
 	return 0;
 }

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
@@ -430,6 +430,27 @@ struct knod_prog {
 #define KNOD_LAT_BUCKETS 10
 #define KNOD_BL_BUCKETS  8
 
+/* Fields of HW_ID1, which GFX10 and up give s_getreg_b32 hwreg(23).  A unit is
+ * named by (shader engine, shader array, workgroup processor), and those three
+ * packed together index the histogram.
+ */
+#define KNOD_HWID_WGP_SHIFT	10
+#define KNOD_HWID_WGP_MASK	0xf
+#define KNOD_HWID_SA_SHIFT	16
+#define KNOD_HWID_SA_MASK	0x1
+#define KNOD_HWID_SE_SHIFT	18
+#define KNOD_HWID_SE_MASK	0x7
+#define KNOD_HWID_SLOTS		256
+
+static inline unsigned int knod_hwid_unit(u32 hwid)
+{
+	unsigned int wgp = (hwid >> KNOD_HWID_WGP_SHIFT) & KNOD_HWID_WGP_MASK;
+	unsigned int sa = (hwid >> KNOD_HWID_SA_SHIFT) & KNOD_HWID_SA_MASK;
+	unsigned int se = (hwid >> KNOD_HWID_SE_SHIFT) & KNOD_HWID_SE_MASK;
+
+	return (se << 5) | (sa << 4) | wgp;
+}
+
 struct knod_bpf_stats {
 	/* The window the counters below were gathered over.  Without it a rate
 	 * can only be inferred from the completion latency and an assumed pipe
@@ -453,6 +474,14 @@ struct knod_bpf_stats {
 	u64 decode_act_total_ns;
 	u64 decode_act_count;
 	u64 decode_act_max_ns;
+
+	/* Packets per compute unit, from the HW_ID a probe build of the blob
+	 * leaves in the half of spsc_bd.act nothing on this path reads.  Zero
+	 * everywhere with an ordinary blob.
+	 */
+	u64 hwid_hist[KNOD_HWID_SLOTS];
+	u64 hwid_units_total;	/* distinct units, summed over dispatches */
+	u64 hwid_dispatches;
 };
 
 #define KNOD_PASS_SLOT_SIZE	PAGE_SIZE


### PR DESCRIPTION
The grid asks for one workgroup per queue per xgroup and the prologue splits
the queue's slots between them, so the geometry is one queue to many
workgroups.  Where those workgroups land is the hardware's to decide, and a
unit with the registers for several may take several - so the geometry can be
one to many while the machine runs it one to one, and throughput alone cannot
tell the two apart.  It was read both ways this week.

With a blob built to leave its `HW_ID` beside each verdict, count the distinct
units a dispatch reached.  On gfx1100, 22 channels, 128 work-items:

| | workgroups asked for | units reached |
|---|---|---|
| `xgroups=1` | 22 | **21.96** |
| `xgroups=2` | 44 | **39.37** (of 40) |

So the hardware does spread them, and asking for twice as many reaches twice
as many.  What it does not do is go faster: the same step took the per-lane
cost from 31.3 ns to 49.0 ns.  **Compute units are not what this is short of.**

## Per dispatch, not per run

The hardware rotates workgroups around the units, so a count kept over a whole
run reaches every unit however few any one dispatch uses.  The first version
counted that way and reported 40 whichever `xgroups` was set to.

The per-unit histogram is kept anyway, because it shows which units the device
has at all - this one has no `se0`, leaving 40 processors for 80 CUs - and
because an even spread is worth being able to see.

## Saying when it is not measuring

An ordinary blob leaves the field this reads at zero, which lands every packet
in slot 0 and reads exactly like the answer the probe was built to look for:
one unit doing everything.  That happened once already, from a build that
missed `make clean`.  The dump now says `(blob has no HW_ID probe)` rather
than letting the shape of the output decide.

Needs knod-blob's `hwid-probe` branch built with `-DKNOD_HWID_PROBE`, and is
BPF-only: IPsec uses the half of `act` this borrows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)