### PR TITLE
net: spsc_ring: name the element alignment, so everyone agrees on it

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -929,7 +929,10 @@ static struct knod_bpf_work_sq *knod_prepare_bpf(struct knod_bpf_priv *priv)
 	sqw->backlogs = backlogs;
 	param->nr_backlogs = backlogs;
 	param->nr_queues = priv->nr_works;
-	param->spsc_stride = ALIGN(sizeof(struct spsc_bd), SMP_CACHE_BYTES);
+	/* From the ring rather than worked out again here: the shader walks the
+	 * pool with this, so it has to be what the pool was laid out with.
+	 */
+	param->spsc_stride = spsc_elem_size(&knodev->wpriv[0].spsc_bds);
 	param->batch_shift = ilog2(priv->batch_size);
 	param->wg_shift = ilog2(knod_bpf_workgroups);
 	param->page_shift = PAGE_SHIFT;
@@ -4258,8 +4261,8 @@ static int knod_prog_prepare_insns(struct knod_bpf_priv *priv,
 	knod_vset32(&param[2], KNOD_AMDGPU_TMP_VREG5_LO);
 	knod_emit(priv, meta, v_and_b32_e32, param[0], param[1], param[2]);
 
-	/* 6. slot_addr = pool_gaddr + slot * spsc_stride, where
-	 *    spsc_stride = ALIGN(sizeof(spsc_bd), SMP_CACHE_BYTES)
+	/* 6. slot_addr = pool_gaddr + slot * spsc_stride, the stride the ring
+	 *    laid its pool out with, which the dispatch passes as a shift.
 	 *    Compute directly into SLOT_VREG (v62:v63).
 	 */
 	knod_vset32(&param[0], KNOD_AMDGPU_SLOT_VREG_LO);

--- a/include/net/spsc_ring.h
+++ b/include/net/spsc_ring.h
@@ -52,6 +52,19 @@
 #include <linux/cache.h>
 #include <asm/barrier.h>
 
+/* Elements are padded to this, so a producer and a consumer working on
+ * neighbouring slots do not share a line.
+ *
+ * Everything that lays out or walks the pool has to agree on it, which is why
+ * it is here and not worked out again at each of them.
+ *
+ * Halving it was tried: knod's shader reads sixteen bytes of a 32-byte
+ * descriptor, so at this stride a wave of 64 lanes touches 64 lines to use 512
+ * bytes.  Packing two to a line made no difference to dispatch time, so the
+ * ring stays where false sharing cannot reach it.
+ */
+#define SPSC_ELEM_ALIGN		SMP_CACHE_BYTES
+
 struct spsc_ring {
 	void		**slots;	/* pointer-per-slot into pool */
 	unsigned int	mask;		/* capacity - 1 */
@@ -89,7 +102,7 @@ struct spsc_ring {
 static inline int __spsc_init(struct spsc_ring *r, unsigned int elem_size,
 			      unsigned int capacity, void *pool, gfp_t gfp)
 {
-	unsigned int stride = ALIGN(elem_size, SMP_CACHE_BYTES);
+	unsigned int stride = ALIGN(elem_size, SPSC_ELEM_ALIGN);
 	unsigned int i;
 	char *base = pool;
 
@@ -128,7 +141,7 @@ static inline int __spsc_init(struct spsc_ring *r, unsigned int elem_size,
 static inline int spsc_init(struct spsc_ring *r, unsigned int elem_size,
 			    unsigned int capacity, gfp_t gfp)
 {
-	unsigned int stride = ALIGN(elem_size, SMP_CACHE_BYTES);
+	unsigned int stride = ALIGN(elem_size, SPSC_ELEM_ALIGN);
 	unsigned long pool_bytes;
 	unsigned int order;
 	struct page *page;

--- a/net/knod/knod_core.c
+++ b/net/knod/knod_core.c
@@ -1032,7 +1032,7 @@ int knod_dev_attach(struct knod_netdev *knetdev, struct knod_accel *accel)
 		unsigned int nqueues = min(knodev->netdev->num_rx_queues,
 					  KNOD_SPSC_MAX);
 		unsigned int stride = ALIGN(sizeof(struct spsc_bd),
-					    SMP_CACHE_BYTES);
+					    SPSC_ELEM_ALIGN);
 		unsigned int cap = roundup_pow_of_two(KNOD_SPSC_ELEMS_MAX);
 		size_t pool_size = (size_t)stride * cap;
 


### PR DESCRIPTION
Four places decided how far apart the ring's elements sit, and each worked it
out for itself:

- `__spsc_init()` and `spsc_init()`, laying out the pool
- `knod_dev_attach()`, sizing the allocation the pool goes in
- `knod_prepare_bpf()`, handing the shader the stride it walks the pool with

They agreed only because they happened to spell the same expression.

## They nearly stopped agreeing

The shader reads sixteen bytes of a 32-byte descriptor, and at a cache line
each a wave of 64 lanes touches 64 lines to take eight bytes of each - so
packing two to a line was worth trying.  Lowering the padding moved two of the
four sites.  The pool was then allocated at one stride while the ring laid its
slots out at another: the slots stayed inside the allocation so nothing broke,
but half of it went unused, and had the last site been the one missed instead,
the shader would have walked the pool with the wrong step.

## What this does

One constant.  The dispatch takes the stride from the ring rather than
deriving it, so the shader steps by what the pool was built with by
construction.

**The value does not change.**  Packing two to a line made no measurable
difference to dispatch time, so the padding stays where false sharing cannot
reach it - and the comment says so, to save the next person the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)