### PR TITLE
drm/amdkfd: knod: decode the unit id for the generation that gave it

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -1022,7 +1022,8 @@ static void knod_hwid_count(struct knod_bpf_priv *priv,
 		r = &knodev->wpriv[i].spsc_bds;
 		for (k = 0; k < sqw->queue_idx[i]; k++) {
 			bd = r->slots[(r->acquired + k) & r->mask];
-			unit = knod_hwid_unit((u32)(bd->act >> 32));
+			unit = knod_hwid_unit((u32)(bd->act >> 32),
+					      priv->isa_version);
 			priv->stats.hwid_hist[unit]++;
 			__set_bit(unit, seen);
 		}
@@ -11952,9 +11953,12 @@ static int knod_stats_show(struct seq_file *s, void *unused)
 			   stats->hwid_dispatches % 100 : 0);
 		for (i = 0; i < KNOD_HWID_SLOTS; i++)
 			if (stats->hwid_hist[i])
-				seq_printf(s, "  se%u sa%u wgp%-2u    %llu\n",
-					   i >> 5, (i >> 4) & 1, i & 0xf,
-					   stats->hwid_hist[i]);
+				seq_printf(s, "  se%u %s%u %s%-2u   %llu\n",
+					   i >> 5,
+					   priv->isa_version == 9 ? "sh" : "sa",
+					   (i >> 4) & 1,
+					   priv->isa_version == 9 ? "cu" : "wgp",
+					   i & 0xf, stats->hwid_hist[i]);
 	}
 
 	return 0;

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
@@ -430,25 +430,32 @@ struct knod_prog {
 #define KNOD_LAT_BUCKETS 10
 #define KNOD_BL_BUCKETS  8
 
-/* Fields of HW_ID1, which GFX10 and up give s_getreg_b32 hwreg(23).  A unit is
- * named by (shader engine, shader array, workgroup processor), and those three
- * packed together index the histogram.
+/* A wave says where it ran through a register the generations neither name nor
+ * lay out alike: GCN keeps it in HW_ID, RDNA split that and put the unit in
+ * HW_ID1.  Both name a unit by (engine, array, unit within the array), and
+ * those three pack the same way whichever generation supplied them - so the
+ * shader stores the register raw and the decoding happens here.
+ *
+ * RDNA counts workgroup processors, each a pair of compute units, so a gfx11
+ * board with 80 CUs reports 40.
  */
-#define KNOD_HWID_WGP_SHIFT	10
-#define KNOD_HWID_WGP_MASK	0xf
-#define KNOD_HWID_SA_SHIFT	16
-#define KNOD_HWID_SA_MASK	0x1
-#define KNOD_HWID_SE_SHIFT	18
-#define KNOD_HWID_SE_MASK	0x7
 #define KNOD_HWID_SLOTS		256
 
-static inline unsigned int knod_hwid_unit(u32 hwid)
+static inline unsigned int knod_hwid_unit(u32 hwid, int isa)
 {
-	unsigned int wgp = (hwid >> KNOD_HWID_WGP_SHIFT) & KNOD_HWID_WGP_MASK;
-	unsigned int sa = (hwid >> KNOD_HWID_SA_SHIFT) & KNOD_HWID_SA_MASK;
-	unsigned int se = (hwid >> KNOD_HWID_SE_SHIFT) & KNOD_HWID_SE_MASK;
+	unsigned int unit, array, engine;
 
-	return (se << 5) | (sa << 4) | wgp;
+	if (isa == 9) {
+		unit = (hwid >> 8) & 0xf;	/* CU_ID  */
+		array = (hwid >> 12) & 0x1;	/* SH_ID  */
+		engine = (hwid >> 13) & 0x3;	/* SE_ID  */
+	} else {
+		unit = (hwid >> 10) & 0xf;	/* WGP_ID */
+		array = (hwid >> 16) & 0x1;	/* SA_ID  */
+		engine = (hwid >> 18) & 0x7;	/* SE_ID  */
+	}
+
+	return (engine << 5) | (array << 4) | unit;
 }
 
 struct knod_bpf_stats {


### PR DESCRIPTION
The HW_ID probe added in #31 reads a register the generations neither name
nor lay out alike.  GCN keeps where a wave ran in `HW_ID`; RDNA split that
register and put the unit in `HW_ID1`, at other bits:

| | register | unit | array | engine |
|---|---|---|---|---|
| GFX9 | `HW_ID` (4) | `CU_ID` [11:8] | `SH_ID` [12] | `SE_ID` [14:13] |
| GFX10+ | `HW_ID1` (23) | `WGP_ID` [13:10] | `SA_ID` [16] | `SE_ID` [20:18] |

Reading gfx9's with gfx11's field positions gives a plausible-looking number
that names the wrong unit - which is the sort of wrong answer this probe
exists to stop producing.

Both generations name a unit by (engine, array, unit within the array), and
those pack the same way whichever supplied them, so the shader stores the
register raw and the decoding moves here where the ISA version is known.

The dump follows: gfx9 says `sh` and `cu`, RDNA says `sa` and `wgp`, since
RDNA counts workgroup processors and each is a pair of compute units - so a
gfx11 board with 80 CUs reports 40 units.

Pairs with knod-blob#12, which teaches the shader side the same split and adds
a `make hwid` target so the flag is not something to remember.

🤖 Generated with [Claude Code](https://claude.com/claude-code)