### PR TITLE
drm/amdkfd: knod: time the shader in three parts

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_amdgpu_insn.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_amdgpu_insn.h
@@ -1884,6 +1884,28 @@ static inline void emit_s_cbranch_execnz(int version, struct amdgcn_insn *insn,
 	}
 }
 
+/* The shader clock counter, whose hwreg id is the same on every generation
+ * that has one.  GFX9 has no equivalent, so a caller there gets nothing.
+ */
+#define KNOD_HWREG_SHADER_CYCLES_20	0x981d
+
+static inline void emit_s_getreg_b32(int version, struct amdgcn_insn *insn,
+				     u8 sdst, u16 hwreg)
+{
+	if (version == 11) {
+		insn->size = emit_gfx11_s_getreg_b32(&insn->gfx11, sdst, hwreg);
+		insn->type = AMDGCN_INSN_TYPE_SOPK;
+	} else if (version == 10) {
+		insn->size = emit_gfx10_s_getreg_b32(&insn->gfx10, sdst, hwreg);
+		insn->type = AMDGCN_INSN_TYPE_SOPK;
+	} else if (version == 9) {
+		insn->size = emit_gfx9_s_getreg_b32(&insn->gfx9, sdst, hwreg);
+		insn->type = AMDGCN_INSN_TYPE_SOPK;
+	} else {
+		WARN_ON_ONCE(1);
+	}
+}
+
 static inline void emit_s_sub_u32(int version, struct amdgcn_insn *insn,
 			   u8 sdst, u8 ssrc0, u8 ssrc1)
 {

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -62,7 +62,7 @@ static_assert(offsetof(struct spsc_bd, page_idx) ==
  * or shrink the other and it would quietly write over a descriptor.
  */
 static_assert(sizeof(struct spsc_bd) <= KNOD_BLOB_BD_PROBE);
-static_assert(KNOD_BLOB_BD_PROBE + (KNOD_PROBE_PARTS + 1) * sizeof(u32) <=
+static_assert(KNOD_BLOB_BD_PROBE + KNOD_PROBE_PARTS * sizeof(u32) <=
 	      ALIGN(sizeof(struct spsc_bd), SPSC_ELEM_ALIGN));
 static_assert(sizeof(struct knod_bpf_subparam_obj) ==
 	      KNOD_BLOB_SUB_SIZE);
@@ -1044,25 +1044,12 @@ static void knod_submit_bpf(struct knod_bpf_priv *priv,
  * mask comes from, and why a part that really did run longer than the counter
  * takes to wrap reads as a small number rather than a large one.
  */
-/* How far @t is from @origin on a counter that wraps at 2^20, as a signed
- * number of clocks.  Good for anything under half a wrap either way, which at
- * a GHz-order shader clock is a couple of hundred microseconds.
- */
-static int knod_cycle_delta(u32 t, u32 origin)
-{
-	u32 d = (t - origin) & 0xfffff;
-
-	return d >= (1u << 19) ? (int)d - (1 << 20) : (int)d;
-}
-
 static void knod_cycle_count(struct knod_bpf_priv *priv,
 			     struct knod_bpf_work_sq *sqw)
 {
 	struct knod_dev *knodev = priv->knodev;
-	int first = 1, lo = 0, hi = 0;
 	struct spsc_ring *r;
 	struct spsc_bd *bd;
-	u32 origin = 0;
 	unsigned int k;
 	int i, j;
 
@@ -1073,8 +1060,6 @@ static void knod_cycle_count(struct knod_bpf_priv *priv,
 		r = &knodev->wpriv[i].spsc_bds;
 		for (k = 0; k < sqw->queue_idx[i]; k++) {
 			const u32 *probe;
-			u32 whole = 0;
-			int start, end;
 
 			bd = r->slots[(r->acquired + k) & r->mask];
 			probe = (const u32 *)((const char *)bd +
@@ -1082,37 +1067,12 @@ static void knod_cycle_count(struct knod_bpf_priv *priv,
 			for (j = 0; j < KNOD_PROBE_PARTS; j++) {
 				u32 c = probe[j] & 0xfffff;
 
-				whole += c;
 				priv->stats.cyc_total[j] += c;
 				if (c > priv->stats.cyc_max[j])
 					priv->stats.cyc_max[j] = c;
 			}
 			priv->stats.cyc_count++;
-
-			/* A lane's end is stamped; its start is that less what
-			 * it spent.  Both against the first lane seen, because
-			 * the counter wraps and only differences mean anything.
-			 */
-			if (first) {
-				origin = probe[KNOD_PROBE_PARTS];
-				first = 0;
-			}
-			end = knod_cycle_delta(probe[KNOD_PROBE_PARTS], origin);
-			start = end - (int)whole;
-			if (start < lo)
-				lo = start;
-			if (end > hi)
-				hi = end;
 		}
-	}
-
-	if (!first) {
-		u64 span = hi - lo;
-
-		priv->stats.cyc_span_total += span;
-		priv->stats.cyc_span_count++;
-		if (span > priv->stats.cyc_span_max)
-			priv->stats.cyc_span_max = span;
 	}
 }
 
@@ -4241,21 +4201,12 @@ static void knod_bpf_emit_cycle_probe(struct knod_bpf_priv *priv,
 			  KNOD_HWREG_SHADER_CYCLES_20);
 		knod_emit(priv, meta, s_sub_u32, KNOD_AMDGPU_TMP_SREG0_HI,
 			  KNOD_AMDGPU_TMP_SREG0_LO, KNOD_AMDGPU_PROBE_SREG1);
-		/* The epilogue's own count, and when it ended.  The second is
-		 * what tells a dispatch's span apart from a wave's: a lane
-		 * started its three counts before it ended, so the earliest
-		 * start and the latest end bound how long the dispatch was
-		 * inside the shader - and the rest came after it.
-		 */
 		knod_vset32(&p[0], KNOD_AMDGPU_TMP_VREG0_LO);
 		knod_sset32(&p[1], KNOD_AMDGPU_TMP_SREG0_HI);
 		knod_emit(priv, meta, v_mov_b32_e32, p[0], p[1]);
-		knod_vset32(&p[0], KNOD_AMDGPU_TMP_VREG0_HI);
-		knod_sset32(&p[1], KNOD_AMDGPU_TMP_SREG0_LO);
-		knod_emit(priv, meta, v_mov_b32_e32, p[0], p[1]);
 		knod_vset32(&p[0], KNOD_AMDGPU_TMP_VREG0_LO);
 		knod_vset32(&p[1], KNOD_AMDGPU_SLOT_VREG_LO);
-		knod_emit(priv, meta, global_store_dwordx2, p[0], p[1],
+		knod_emit(priv, meta, global_store_dword, p[0], p[1],
 			  KNOD_BLOB_BD_PROBE + 8);
 		break;
 	}
@@ -12176,16 +12127,6 @@ static int knod_stats_show(struct seq_file *s, void *unused)
 		seq_printf(s, "%-9s avg %8llu\n", "total",
 			   whole / stats->cyc_count);
 
-		/* One wave's time against the whole dispatch's.  What the
-		 * span does not account for is what the dispatch spent with
-		 * no wave running - before the first was launched and after
-		 * the last one's stores were seen.
-		 */
-		if (stats->cyc_span_count)
-			seq_printf(s,
-				   "span      avg %8llu  max %8llu (per dispatch)\n",
-				   stats->cyc_span_total / stats->cyc_span_count,
-				   stats->cyc_span_max);
 no_cycles:
 		;
 	}

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -354,6 +354,27 @@ static_assert(sizeof(struct knod_bpf_subparam_obj) ==
  */
 #define KNOD_AMDGPU_SGPRS_USED		(KNOD_AMDGPU_INITIAL_EXEC_SREG + 2)
 
+/* The cycle probe holds two values across the program: what the prologue
+ * took, and when it ended.  s[32:33] is the pair nothing else claims - GFX9
+ * corrupts it, which costs nothing here because GFX9 has no counter to read
+ * either.  Everything else the probe needs it works out inside the epilogue,
+ * where the scratch scalars are free again.
+ */
+#define KNOD_AMDGPU_PROBE_SREG0		32
+#define KNOD_AMDGPU_PROBE_SREG1		33
+
+enum knod_probe_stage {
+	KNOD_PROBE_PRO_START,
+	KNOD_PROBE_PRO_END,
+	KNOD_PROBE_EPI_START,
+	KNOD_PROBE_EPI_END,
+};
+
+/* spsc_bd is half of the 64-byte slot it sits in; the probe writes its three
+ * counts into the half nothing reads.
+ */
+#define KNOD_PROBE_BD_OFF		32
+
 static u8 knod_bpf_gfx9_sgpr_granule(unsigned int sgprs_used)
 {
 	if (sgprs_used <= 16)
@@ -378,6 +399,19 @@ module_param_named(queue_expire, knod_bpf_expire, int, 0600);
 unsigned int knod_bpf_pkt_cache = 1;
 MODULE_PARM_DESC(packet_cache, "Use packet cache, 0=Off, 1=On(Default)");
 module_param_named(packet_cache, knod_bpf_pkt_cache, int, 0600);
+
+/* Where the shader's time goes, in shader clocks, split three ways: the
+ * prologue, the program, and the epilogue.  Each wave writes its own three
+ * into the tail of its ring slot, which spsc_bd leaves free, and the host
+ * histograms them - so the answer is per wave rather than an average of the
+ * whole dispatch.
+ *
+ * Only the kernel emitter grows the probe, so it wants jit_engine=0, and only
+ * where there is a counter to read: GFX9 has none.
+ */
+unsigned int knod_bpf_cycle_probe;
+MODULE_PARM_DESC(cycle_probe, "Time the shader in three parts, 0=Off(Default)");
+module_param_named(cycle_probe, knod_bpf_cycle_probe, int, 0600);
 
 /* Where the routines that have a prebuilt form come from.  "kernel" emits them
  * as it always has, and is what runs when no blob is installed; "blob" splices
@@ -1003,6 +1037,43 @@ static void knod_submit_bpf(struct knod_bpf_priv *priv,
  * per dispatch is what says whether asking for more workgroups per queue
  * actually reaches more units.
  */
+/* Gather what the cycle probe left in each slot's spare half.  The counter is
+ * twenty bits, so a difference is only right modulo that - which is where the
+ * mask comes from, and why a part that really did run longer than the counter
+ * takes to wrap reads as a small number rather than a large one.
+ */
+static void knod_cycle_count(struct knod_bpf_priv *priv,
+			     struct knod_bpf_work_sq *sqw)
+{
+	struct knod_dev *knodev = priv->knodev;
+	struct spsc_ring *r;
+	struct spsc_bd *bd;
+	unsigned int k;
+	int i, j;
+
+	for (i = 0; i < priv->nr_works; i++) {
+		if (sqw->queue_idx[i] < 1)
+			continue;
+
+		r = &knodev->wpriv[i].spsc_bds;
+		for (k = 0; k < sqw->queue_idx[i]; k++) {
+			const u32 *probe;
+
+			bd = r->slots[(r->acquired + k) & r->mask];
+			probe = (const u32 *)((const char *)bd +
+					      KNOD_PROBE_BD_OFF);
+			for (j = 0; j < KNOD_PROBE_PARTS; j++) {
+				u64 c = probe[j] & 0xfffff;
+
+				priv->stats.cyc_total[j] += c;
+				if (c > priv->stats.cyc_max[j])
+					priv->stats.cyc_max[j] = c;
+			}
+			priv->stats.cyc_count++;
+		}
+	}
+}
+
 static void knod_hwid_count(struct knod_bpf_priv *priv,
 			    struct knod_bpf_work_sq *sqw)
 {
@@ -1041,6 +1112,13 @@ static void knod_complete_acquire(struct knod_bpf_priv *priv,
 
 	if (static_branch_unlikely(&knod_stats_key))
 		knod_hwid_count(priv, sqw);
+
+	/* Either engine can carry the probe - the kernel emitter when it is
+	 * told to, a blob when it was built with it - so collect on both and
+	 * let the counts say whether anything wrote them.
+	 */
+	if (knod_bpf_cycle_probe)
+		knod_cycle_count(priv, sqw);
 
 	for (i = 0; i < priv->nr_works; i++) {
 		if (sqw->queue_idx[i] >= 1) {
@@ -4047,6 +4125,91 @@ static void knod_global_store_size_cache(struct knod_bpf_priv *priv,
 	knod_wait_vmcnt(priv, meta);
 }
 
+/*
+ * Read the shader clock and, at the stages that end an interval, work out how
+ * long that interval was and put it in the slot's spare half.
+ *
+ * The counter is twenty bits and free-running, so a difference is only right
+ * modulo that; the host masks what it reads.  Nothing here waits on anything -
+ * s_getreg is a register read - so the probe adds its own issue cost to the
+ * interval it closes and nothing else.  The two stores land in the epilogue,
+ * after its last reading, so they price themselves out of it.
+ */
+static void knod_bpf_emit_cycle_probe(struct knod_bpf_priv *priv,
+				      struct knod_insn_meta *meta,
+				      enum knod_probe_stage stage)
+{
+	struct amdgcn_param32 p[2];
+
+	/* All four stages or none: a blob supplies the prologue and the
+	 * epilogue whole, so with that engine the probe would only ever get
+	 * half of itself in and report on nothing.
+	 */
+	if (!knod_bpf_cycle_probe || knod_bpf_jit_engine ||
+	    priv->isa_version < 10)
+		return;
+
+	switch (stage) {
+	case KNOD_PROBE_PRO_START:
+		knod_emit(priv, meta, s_getreg_b32, KNOD_AMDGPU_PROBE_SREG0,
+			  KNOD_HWREG_SHADER_CYCLES_20);
+		break;
+	case KNOD_PROBE_PRO_END:
+		/* s32 becomes what the prologue took, s33 when it ended. */
+		knod_emit(priv, meta, s_getreg_b32, KNOD_AMDGPU_PROBE_SREG1,
+			  KNOD_HWREG_SHADER_CYCLES_20);
+		knod_emit(priv, meta, s_sub_u32, KNOD_AMDGPU_PROBE_SREG0,
+			  KNOD_AMDGPU_PROBE_SREG1, KNOD_AMDGPU_PROBE_SREG0);
+		break;
+	case KNOD_PROBE_EPI_START:
+		/* The program is over, so its count can be worked out and both
+		 * finished counts written away; s33 then times the epilogue.
+		 *
+		 * Whatever the program left EXEC as, every in-bounds lane has
+		 * a count to report, and the epilogue sets EXEC for itself
+		 * straight after this.
+		 */
+		knod_emit(priv, meta, s_mov_b64, AMDGCN_SREG_EXEC_LO,
+			  KNOD_AMDGPU_INITIAL_EXEC_SREG);
+		knod_emit(priv, meta, s_getreg_b32, KNOD_AMDGPU_TMP_SREG0_LO,
+			  KNOD_HWREG_SHADER_CYCLES_20);
+		knod_emit(priv, meta, s_sub_u32, KNOD_AMDGPU_TMP_SREG0_HI,
+			  KNOD_AMDGPU_TMP_SREG0_LO, KNOD_AMDGPU_PROBE_SREG1);
+		knod_vset32(&p[0], KNOD_AMDGPU_TMP_VREG0_LO);
+		knod_sset32(&p[1], KNOD_AMDGPU_PROBE_SREG0);
+		knod_emit(priv, meta, v_mov_b32_e32, p[0], p[1]);
+		knod_vset32(&p[0], KNOD_AMDGPU_TMP_VREG0_HI);
+		knod_sset32(&p[1], KNOD_AMDGPU_TMP_SREG0_HI);
+		knod_emit(priv, meta, v_mov_b32_e32, p[0], p[1]);
+		knod_vset32(&p[0], KNOD_AMDGPU_TMP_VREG0_LO);
+		knod_vset32(&p[1], KNOD_AMDGPU_SLOT_VREG_LO);
+		knod_emit(priv, meta, global_store_dwordx2, p[0], p[1],
+			  KNOD_PROBE_BD_OFF);
+		knod_sset32(&p[0], KNOD_AMDGPU_PROBE_SREG1);
+		knod_sset32(&p[1], KNOD_AMDGPU_TMP_SREG0_LO);
+		knod_emit(priv, meta, s_mov_b32, p[0], p[1]);
+		break;
+	case KNOD_PROBE_EPI_END:
+		/* The PASS path left EXEC narrowed to the lanes that took it,
+		 * and every lane wants to report.
+		 */
+		knod_emit(priv, meta, s_mov_b64, AMDGCN_SREG_EXEC_LO,
+			  KNOD_AMDGPU_INITIAL_EXEC_SREG);
+		knod_emit(priv, meta, s_getreg_b32, KNOD_AMDGPU_TMP_SREG0_LO,
+			  KNOD_HWREG_SHADER_CYCLES_20);
+		knod_emit(priv, meta, s_sub_u32, KNOD_AMDGPU_TMP_SREG0_HI,
+			  KNOD_AMDGPU_TMP_SREG0_LO, KNOD_AMDGPU_PROBE_SREG1);
+		knod_vset32(&p[0], KNOD_AMDGPU_TMP_VREG0_LO);
+		knod_sset32(&p[1], KNOD_AMDGPU_TMP_SREG0_HI);
+		knod_emit(priv, meta, v_mov_b32_e32, p[0], p[1]);
+		knod_vset32(&p[0], KNOD_AMDGPU_TMP_VREG0_LO);
+		knod_vset32(&p[1], KNOD_AMDGPU_SLOT_VREG_LO);
+		knod_emit(priv, meta, global_store_dword, p[0], p[1],
+			  KNOD_PROBE_BD_OFF + 8);
+		break;
+	}
+}
+
 static int knod_prog_prepare_insns(struct knod_bpf_priv *priv,
 				   struct knod_prog *knod_prog)
 {
@@ -4085,6 +4248,8 @@ static int knod_prog_prepare_insns(struct knod_bpf_priv *priv,
 	 */
 	knod_emit(priv, meta, s_icache_inv);
 	knod_emit(priv, meta, s_waitcnt_vmcnt_lgkmcnt);
+
+	knod_bpf_emit_cycle_probe(priv, meta, KNOD_PROBE_PRO_START);
 
 	knod_sset32(&param[0], KNOD_AMDGPU_PARAM_SREG_LO);
 	knod_sset32(&param[1], KNOD_AMDGPU_ARG_SREG);
@@ -4402,6 +4567,8 @@ static int knod_prog_prepare_insns(struct knod_bpf_priv *priv,
 	/* Step 10 eliminated: data->DATA_VREG, data_end->DATA_END_VREG,
 	 * slot_addr->SLOT_VREG computed directly in steps 6/8/9 above.
 	 */
+
+	knod_bpf_emit_cycle_probe(priv, meta, KNOD_PROBE_PRO_END);
 
 	pr_debug("knod_bpf DEBUG: prologue emitted idx=%u (KNOD_META_INSNS=%d)\n",
 		 meta->amdgpu_insns, KNOD_META_INSNS);
@@ -9149,6 +9316,8 @@ static int knod_bpf_emit_epilogue(struct knod_bpf_priv *priv,
 	if (meta->blob)
 		goto pkt_cache_writeback;
 
+	knod_bpf_emit_cycle_probe(priv, meta, KNOD_PROBE_EPI_START);
+
 	/* Any in-bounds lane outside done_mask gets a conservative DROP
 	 * verdict instead of publishing stale VGPR state or leaving the
 	 * recycle-time poison in bd->act.
@@ -9314,6 +9483,11 @@ pkt_cache_writeback:
 	emit_s_cbranch_vccz(priv->isa_version,
 			    &meta->amdgpu_insn[pass_branch_idx],
 			    pass_dwords);
+
+	/* After the branch is measured, so both paths reach it: the one that
+	 * passed falls through and the one that did not lands here.
+	 */
+	knod_bpf_emit_cycle_probe(priv, meta, KNOD_PROBE_EPI_END);
 
 	knod_emit(priv, meta, s_endpgm);
 
@@ -11926,6 +12100,33 @@ static int knod_stats_show(struct seq_file *s, void *unused)
 		   stats->decode_act_count ?
 		   stats->decode_act_total_ns / stats->decode_act_count : 0);
 	seq_printf(s, "max_ns:              %llu\n", stats->decode_act_max_ns);
+
+	if (stats->cyc_count) {
+		static const char * const part[KNOD_PROBE_PARTS] = {
+			"prologue", "program", "epilogue",
+		};
+		u64 whole = 0;
+
+		for (i = 0; i < KNOD_PROBE_PARTS; i++)
+			whole += stats->cyc_total[i];
+
+		seq_puts(s, "\n--- shader clocks ---\n");
+		if (!whole) {
+			seq_puts(s, "lanes:               (shader has no cycle probe)\n");
+			goto no_cycles;
+		}
+		seq_printf(s, "lanes:               %llu\n", stats->cyc_count);
+		for (i = 0; i < KNOD_PROBE_PARTS; i++)
+			seq_printf(s, "%-9s avg %8llu  max %8llu  %2llu%%\n",
+				   part[i],
+				   stats->cyc_total[i] / stats->cyc_count,
+				   stats->cyc_max[i],
+				   stats->cyc_total[i] * 100 / whole);
+		seq_printf(s, "%-9s avg %8llu\n", "total",
+			   whole / stats->cyc_count);
+no_cycles:
+		;
+	}
 
 	/* The grid asks for groups_per_queue workgroups per queue; this says how
 	 * many units they actually reached.

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -1042,12 +1042,25 @@ static void knod_submit_bpf(struct knod_bpf_priv *priv,
  * mask comes from, and why a part that really did run longer than the counter
  * takes to wrap reads as a small number rather than a large one.
  */
+/* How far @t is from @origin on a counter that wraps at 2^20, as a signed
+ * number of clocks.  Good for anything under half a wrap either way, which at
+ * a GHz-order shader clock is a couple of hundred microseconds.
+ */
+static int knod_cycle_delta(u32 t, u32 origin)
+{
+	u32 d = (t - origin) & 0xfffff;
+
+	return d >= (1u << 19) ? (int)d - (1 << 20) : (int)d;
+}
+
 static void knod_cycle_count(struct knod_bpf_priv *priv,
 			     struct knod_bpf_work_sq *sqw)
 {
 	struct knod_dev *knodev = priv->knodev;
+	int first = 1, lo = 0, hi = 0;
 	struct spsc_ring *r;
 	struct spsc_bd *bd;
+	u32 origin = 0;
 	unsigned int k;
 	int i, j;
 
@@ -1058,19 +1071,46 @@ static void knod_cycle_count(struct knod_bpf_priv *priv,
 		r = &knodev->wpriv[i].spsc_bds;
 		for (k = 0; k < sqw->queue_idx[i]; k++) {
 			const u32 *probe;
+			u32 whole = 0;
+			int start, end;
 
 			bd = r->slots[(r->acquired + k) & r->mask];
 			probe = (const u32 *)((const char *)bd +
 					      KNOD_PROBE_BD_OFF);
 			for (j = 0; j < KNOD_PROBE_PARTS; j++) {
-				u64 c = probe[j] & 0xfffff;
+				u32 c = probe[j] & 0xfffff;
 
+				whole += c;
 				priv->stats.cyc_total[j] += c;
 				if (c > priv->stats.cyc_max[j])
 					priv->stats.cyc_max[j] = c;
 			}
 			priv->stats.cyc_count++;
+
+			/* A lane's end is stamped; its start is that less what
+			 * it spent.  Both against the first lane seen, because
+			 * the counter wraps and only differences mean anything.
+			 */
+			if (first) {
+				origin = probe[KNOD_PROBE_PARTS];
+				first = 0;
+			}
+			end = knod_cycle_delta(probe[KNOD_PROBE_PARTS], origin);
+			start = end - (int)whole;
+			if (start < lo)
+				lo = start;
+			if (end > hi)
+				hi = end;
 		}
+	}
+
+	if (!first) {
+		u64 span = hi - lo;
+
+		priv->stats.cyc_span_total += span;
+		priv->stats.cyc_span_count++;
+		if (span > priv->stats.cyc_span_max)
+			priv->stats.cyc_span_max = span;
 	}
 }
 
@@ -4199,12 +4239,21 @@ static void knod_bpf_emit_cycle_probe(struct knod_bpf_priv *priv,
 			  KNOD_HWREG_SHADER_CYCLES_20);
 		knod_emit(priv, meta, s_sub_u32, KNOD_AMDGPU_TMP_SREG0_HI,
 			  KNOD_AMDGPU_TMP_SREG0_LO, KNOD_AMDGPU_PROBE_SREG1);
+		/* The epilogue's own count, and when it ended.  The second is
+		 * what tells a dispatch's span apart from a wave's: a lane
+		 * started its three counts before it ended, so the earliest
+		 * start and the latest end bound how long the dispatch was
+		 * inside the shader - and the rest came after it.
+		 */
 		knod_vset32(&p[0], KNOD_AMDGPU_TMP_VREG0_LO);
 		knod_sset32(&p[1], KNOD_AMDGPU_TMP_SREG0_HI);
 		knod_emit(priv, meta, v_mov_b32_e32, p[0], p[1]);
+		knod_vset32(&p[0], KNOD_AMDGPU_TMP_VREG0_HI);
+		knod_sset32(&p[1], KNOD_AMDGPU_TMP_SREG0_LO);
+		knod_emit(priv, meta, v_mov_b32_e32, p[0], p[1]);
 		knod_vset32(&p[0], KNOD_AMDGPU_TMP_VREG0_LO);
 		knod_vset32(&p[1], KNOD_AMDGPU_SLOT_VREG_LO);
-		knod_emit(priv, meta, global_store_dword, p[0], p[1],
+		knod_emit(priv, meta, global_store_dwordx2, p[0], p[1],
 			  KNOD_PROBE_BD_OFF + 8);
 		break;
 	}
@@ -12124,6 +12173,17 @@ static int knod_stats_show(struct seq_file *s, void *unused)
 				   stats->cyc_total[i] * 100 / whole);
 		seq_printf(s, "%-9s avg %8llu\n", "total",
 			   whole / stats->cyc_count);
+
+		/* One wave's time against the whole dispatch's.  What the
+		 * span does not account for is what the dispatch spent with
+		 * no wave running - before the first was launched and after
+		 * the last one's stores were seen.
+		 */
+		if (stats->cyc_span_count)
+			seq_printf(s,
+				   "span      avg %8llu  max %8llu (per dispatch)\n",
+				   stats->cyc_span_total / stats->cyc_span_count,
+				   stats->cyc_span_max);
 no_cycles:
 		;
 	}

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -58,6 +58,12 @@ static_assert(offsetof(struct spsc_bd, off) ==
 	      KNOD_BLOB_BD_OFF);
 static_assert(offsetof(struct spsc_bd, page_idx) ==
 	      KNOD_BLOB_BD_PAGE_IDX);
+/* The probe writes past spsc_bd and inside the slot it sits in.  Grow the one
+ * or shrink the other and it would quietly write over a descriptor.
+ */
+static_assert(sizeof(struct spsc_bd) <= KNOD_BLOB_BD_PROBE);
+static_assert(KNOD_BLOB_BD_PROBE + (KNOD_PROBE_PARTS + 1) * sizeof(u32) <=
+	      ALIGN(sizeof(struct spsc_bd), SPSC_ELEM_ALIGN));
 static_assert(sizeof(struct knod_bpf_subparam_obj) ==
 	      KNOD_BLOB_SUB_SIZE);
 
@@ -370,10 +376,6 @@ enum knod_probe_stage {
 	KNOD_PROBE_EPI_END,
 };
 
-/* spsc_bd is half of the 64-byte slot it sits in; the probe writes its three
- * counts into the half nothing reads.
- */
-#define KNOD_PROBE_BD_OFF		32
 
 static u8 knod_bpf_gfx9_sgpr_granule(unsigned int sgprs_used)
 {
@@ -1076,7 +1078,7 @@ static void knod_cycle_count(struct knod_bpf_priv *priv,
 
 			bd = r->slots[(r->acquired + k) & r->mask];
 			probe = (const u32 *)((const char *)bd +
-					      KNOD_PROBE_BD_OFF);
+					      KNOD_BLOB_BD_PROBE);
 			for (j = 0; j < KNOD_PROBE_PARTS; j++) {
 				u32 c = probe[j] & 0xfffff;
 
@@ -4224,7 +4226,7 @@ static void knod_bpf_emit_cycle_probe(struct knod_bpf_priv *priv,
 		knod_vset32(&p[0], KNOD_AMDGPU_TMP_VREG0_LO);
 		knod_vset32(&p[1], KNOD_AMDGPU_SLOT_VREG_LO);
 		knod_emit(priv, meta, global_store_dwordx2, p[0], p[1],
-			  KNOD_PROBE_BD_OFF);
+			  KNOD_BLOB_BD_PROBE);
 		knod_sset32(&p[0], KNOD_AMDGPU_PROBE_SREG1);
 		knod_sset32(&p[1], KNOD_AMDGPU_TMP_SREG0_LO);
 		knod_emit(priv, meta, s_mov_b32, p[0], p[1]);
@@ -4254,7 +4256,7 @@ static void knod_bpf_emit_cycle_probe(struct knod_bpf_priv *priv,
 		knod_vset32(&p[0], KNOD_AMDGPU_TMP_VREG0_LO);
 		knod_vset32(&p[1], KNOD_AMDGPU_SLOT_VREG_LO);
 		knod_emit(priv, meta, global_store_dwordx2, p[0], p[1],
-			  KNOD_PROBE_BD_OFF + 8);
+			  KNOD_BLOB_BD_PROBE + 8);
 		break;
 	}
 }

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
@@ -440,6 +440,8 @@ struct knod_prog {
  * board with 80 CUs reports 40.
  */
 #define KNOD_HWID_SLOTS		256
+/* Prologue, program, epilogue. */
+#define KNOD_PROBE_PARTS	3
 
 static inline unsigned int knod_hwid_unit(u32 hwid, int isa)
 {
@@ -489,6 +491,13 @@ struct knod_bpf_stats {
 	u64 hwid_hist[KNOD_HWID_SLOTS];
 	u64 hwid_units_total;	/* distinct units, summed over dispatches */
 	u64 hwid_dispatches;
+
+	/* Shader clocks per wave, split three ways, from what the cycle probe
+	 * leaves in the spare half of a ring slot.  Zero unless it is armed.
+	 */
+	u64 cyc_total[KNOD_PROBE_PARTS];
+	u64 cyc_max[KNOD_PROBE_PARTS];
+	u64 cyc_count;
 };
 
 #define KNOD_PASS_SLOT_SIZE	PAGE_SIZE

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
@@ -498,12 +498,6 @@ struct knod_bpf_stats {
 	u64 cyc_total[KNOD_PROBE_PARTS];
 	u64 cyc_max[KNOD_PROBE_PARTS];
 	u64 cyc_count;
-	/* Earliest lane start to latest lane end, per dispatch: how much of a
-	 * dispatch's wall time the shader was running for any of it.
-	 */
-	u64 cyc_span_total;
-	u64 cyc_span_max;
-	u64 cyc_span_count;
 };
 
 #define KNOD_PASS_SLOT_SIZE	PAGE_SIZE

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
@@ -498,6 +498,12 @@ struct knod_bpf_stats {
 	u64 cyc_total[KNOD_PROBE_PARTS];
 	u64 cyc_max[KNOD_PROBE_PARTS];
 	u64 cyc_count;
+	/* Earliest lane start to latest lane end, per dispatch: how much of a
+	 * dispatch's wall time the shader was running for any of it.
+	 */
+	u64 cyc_span_total;
+	u64 cyc_span_max;
+	u64 cyc_span_count;
 };
 
 #define KNOD_PASS_SLOT_SIZE	PAGE_SIZE

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_gfx10_insn.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_gfx10_insn.h
@@ -3519,6 +3519,28 @@ inline u32 emit_gfx10_s_cbranch_execnz(union amdgcn_gfx10_insn *insn,
 	return 4;
 }
 
+/* --- SOPK: s_getreg_b32 --- */
+
+/*
+ * simm16 for s_getreg_b32:
+ *   bits[5:0]   hwreg id
+ *   bits[10:6]  first bit
+ *   bits[15:11] width - 1
+ */
+#define GFX10_HWREG(id, off, sz)	(((sz) - 1) << 11 | (off) << 6 | (id))
+/* A free-running count of shader clocks, twenty bits wide. */
+#define GFX10_HW_REG_SHADER_CYCLES	29
+
+inline u32 emit_gfx10_s_getreg_b32(union amdgcn_gfx10_insn *insn,
+				   int sdst, u16 hwreg)
+{
+	insn->sopk.encoding = GFX10_SOPK_ENCODING;
+	insn->sopk.op = GFX10_S_GETREG_B32;
+	insn->sopk.sdst = sdst;
+	insn->sopk.simm16 = hwreg;
+	return 4;
+}
+
 /* s_sub_u32 sdst, ssrc0, ssrc1 - sdst = ssrc0 - ssrc1; SCC = borrow */
 inline u32 emit_gfx10_s_sub_u32(union amdgcn_gfx10_insn *insn,
 				 u8 sdst, u8 ssrc0, u8 ssrc1)

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_gfx11_insn.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_gfx11_insn.h
@@ -2050,6 +2050,28 @@ DEFINE_GFX11_VOP3_2SRC(v_mbcnt_hi_u32_b32, GFX11_V_MBCNT_HI_U32_B32)
 
 #undef DEFINE_GFX11_VOP3_3SRC
 
+/* --- SOPK: s_getreg_b32 --- */
+
+/*
+ * simm16 for s_getreg_b32:
+ *   bits[5:0]   hwreg id
+ *   bits[10:6]  first bit
+ *   bits[15:11] width - 1
+ */
+#define GFX11_HWREG(id, off, sz)	(((sz) - 1) << 11 | (off) << 6 | (id))
+/* A free-running count of shader clocks, twenty bits wide. */
+#define GFX11_HW_REG_SHADER_CYCLES	29
+
+static inline u32 emit_gfx11_s_getreg_b32(union amdgcn_gfx11_insn *insn,
+				   int sdst, u16 hwreg)
+{
+	insn->sopk.encoding = GFX11_SOPK_ENCODING;
+	insn->sopk.op = GFX11_S_GETREG_B32;
+	insn->sopk.sdst = sdst;
+	insn->sopk.simm16 = hwreg;
+	return 4;
+}
+
 /* --- VOP3SD (carry-out to an SGPR pair; VCC here) --- */
 
 static inline u32 emit_gfx11_v_add_co_u32(union amdgcn_gfx11_insn *insn,

--- a/include/uapi/linux/knod_blob.h
+++ b/include/uapi/linux/knod_blob.h
@@ -195,6 +195,12 @@ enum knod_blob_kind {
  * routine names them without asking which GPU it was built for.
  */
 #define KNOD_BLOB_DONE_MASK_SREG	34
+/* What a probe build holds across the program: what the prologue took, and
+ * when it ended.  s[32:33] is the pair nothing else claims - GFX9 corrupts it,
+ * which costs nothing because GFX9 has no cycle counter to read either.
+ */
+#define KNOD_BLOB_PROBE_SREG		32
+
 #define KNOD_BLOB_INITIAL_EXEC_SREG	100
 
 /*
@@ -340,6 +346,12 @@ struct knod_blob_map_desc {
 #define KNOD_BLOB_SUB_EGRESS_IFINDEX	40
 #define KNOD_BLOB_SUB_RETVAL		48
 #define KNOD_BLOB_SUB_SIZE		56
+
+/* spsc_bd fills half of the 64-byte slot it sits in.  A probe build puts its
+ * three counts - prologue, program, epilogue - in the half nothing reads, so
+ * carrying them costs no layout and no version.
+ */
+#define KNOD_BLOB_BD_PROBE		32
 
 /* The BPF stack the frame pointer starts at the top of. */
 #define KNOD_BLOB_BPF_STACK_SIZE	512

--- a/include/uapi/linux/knod_blob.h
+++ b/include/uapi/linux/knod_blob.h
@@ -350,6 +350,12 @@ struct knod_blob_map_desc {
 /* spsc_bd fills half of the 64-byte slot it sits in.  A probe build puts its
  * three counts - prologue, program, epilogue - in the half nothing reads, so
  * carrying them costs no layout and no version.
+ *
+ * Counts and not stamps: the counter one is read from is per compute unit, so
+ * two waves that ran on different ones have no common origin and the earliest
+ * start across a dispatch cannot be told.  Stamping the end was tried, and the
+ * spread it reported was the counter's own range.  What is comparable is a
+ * difference taken inside one wave, which is what these are.
  */
 #define KNOD_BLOB_BD_PROBE		32
 


### PR DESCRIPTION
Where the shader's time goes had been guessed at from the outside, by changing
something and watching throughput, and the throughput was not steady enough to
answer. This asks the shader.

`cycle_probe=1` has the JIT read `HW_REG_SHADER_CYCLES` at four points — the top
of the prologue, its end, the top of the epilogue, and the last thing before
`s_endpgm` — and each wave writes the three differences into the tail of its ring
slot, which `spsc_bd` fills half of. So this carries no layout and no ABI version,
and `stats` histograms it.

Either engine can produce them: the emitter behind `cycle_probe=1` (which also
wants `jit_engine=0`, because a blob supplies the prologue and epilogue whole), or
a blob built with its own probe. A shader without one leaves the counts at zero,
which `stats` says rather than letting the shape of the output decide.

What it found, gfx1100, `return XDP_DROP`, 22 queues:

```
prologue  19,105    program  3,271    epilogue  165    total  22,542
```

9 µs at 2.5 GHz, against a dispatch latency of 113 — **the shader is 5%**.

`s_getreg_b32` grows GFX10 and GFX11 encoders, whose opcodes differ from each
other and from GFX9's (18, 17, 17). GFX9 has no such register, so the probe is
GFX10 and up.

A fourth stamp, meant to bound how much of a dispatch had any wave running, is
removed again in the last commit: the counter is per compute unit, so two waves
on different ones share no origin, and the spread it reported was the counter's
own range. Why it cannot work is written down next to the counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)