### PR TITLE
drm/amdkfd: knod: let a BPF map be cached, and agree with the shader on its free list

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -1739,7 +1739,7 @@ static int knod_bpf_map_hash_init_elem(struct knod_bpf_map *knod_map,
 		e->next = KNOD_BPF_HASH_NEXT_END;
 		queue[i] = i;
 	}
-	knod_map_obj->meta.hmeta.cur = knod_map_obj->max_entries - 1;
+	knod_map_obj->meta.hmeta.cur = knod_map_obj->max_entries;
 
 	return 0;
 }
@@ -2022,13 +2022,17 @@ knod_bpf_map_hash_pop(struct knod_bpf_map *knod_map,
 	struct knod_bpf_hash_elem_obj *e;
 	int elem_id;
 
-	if (knod_map_obj->meta.hmeta.cur < 1)
+	/* The count is what is free and the queue is a stack of that many, so
+	 * the element to take is the one below the top.  Signed, because the
+	 * shader decrements before it knows whether there was anything left.
+	 */
+	if ((int)knod_map_obj->meta.hmeta.cur <= 0)
 		return NULL;
 
+	knod_map_obj->meta.hmeta.cur--;
 	elem_id = queue[knod_map_obj->meta.hmeta.cur];
 	knod_jit_dbg(" elem_id = 0x%x\n", elem_id);
 	e = elems + (elem_id * knod_map_obj->meta.hmeta.elem_size);
-	knod_map_obj->meta.hmeta.cur--;
 	e->next = KNOD_BPF_HASH_NEXT_END;
 
 	return e;

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -1809,7 +1809,6 @@ static int __knod_bpf_map_alloc(struct knod_dev *knodev,
 	int order, size, queue_size, i, value_size, nents, err;
 	int n_instances = 1;
 	int flags = KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE |
-		    KFD_IOC_ALLOC_MEM_FLAGS_COHERENT |
 		    KFD_IOC_ALLOC_MEM_FLAGS_PUBLIC |
 		    KFD_IOC_ALLOC_MEM_FLAGS_VRAM;
 	struct knod_bpf_map_obj *knod_map_obj;
@@ -2375,19 +2374,28 @@ static int __knod_bpf_map_lookup_elem(struct bpf_offloaded_map *offmap,
 	return 0;
 }
 
+#define KNOD_MAP_QUIESCE_MS	100
+
 static void knod_bpf_map_op_begin(struct knod_bpf_priv *priv)
 {
-	/*
-	 * Serialize concurrent map ops but do NOT park the worker: stopping it
-	 * mid-flight strands the in-flight dispatch and stalls the GPU compute
-	 * queue.  A map value updated while the GPU reads it may be seen torn,
-	 * which is a transient inconsistency the BPF prog tolerates.
-	 */
+	/* A cached map is written between dispatches, not under one. */
 	mutex_lock(&priv->map_op_lock);
+
+	if (!priv->worker_task)
+		return;
+
+	WRITE_ONCE(priv->map_op_quiesce, true);
+	if (!wait_event_timeout(priv->map_op_wq, !priv->inflight_cnt,
+				msecs_to_jiffies(KNOD_MAP_QUIESCE_MS)))
+		pr_warn_once("knod_bpf: map op did not see the pipe empty in %ums; a dispatch is stuck\n",
+			     KNOD_MAP_QUIESCE_MS);
 }
 
 static void knod_bpf_map_op_end(struct knod_bpf_priv *priv)
 {
+	WRITE_ONCE(priv->map_op_quiesce, false);
+	wake_up(&priv->map_op_wq);
+
 	knod_bpf_gpu_mem_fence(priv);
 	mutex_unlock(&priv->map_op_lock);
 }
@@ -2752,8 +2760,13 @@ static int knod_bpf_worker(void *arg)
 		/* Keep the pipe full: dispatch ahead up to KNOD_BPF_INFLIGHT.
 		 * Staging self-limits, so this stops once the ring is drained.
 		 */
-		while (knod_bpf_submit_work(priv))
-			progressed = true;
+		if (unlikely(READ_ONCE(priv->map_op_quiesce))) {
+			if (!priv->inflight_cnt)
+				wake_up(&priv->map_op_wq);
+		} else {
+			while (knod_bpf_submit_work(priv))
+				progressed = true;
+		}
 		rcu_read_unlock_bh();
 
 		if (!priv->inflight_cnt) {
@@ -2893,6 +2906,7 @@ static int knod_priv_init(struct knod_bpf_priv *priv)
 
 	priv->prog = NULL;
 	mutex_init(&priv->map_op_lock);
+	init_waitqueue_head(&priv->map_op_wq);
 	INIT_LIST_HEAD(&priv->dead_maps);
 	priv->maps_tick_skip = 0;
 

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
@@ -43,6 +43,7 @@
 #include <linux/workqueue.h>
 #include <linux/ktime.h>
 #include <linux/static_key.h>
+#include <linux/wait.h>
 #include <uapi/linux/knod_blob.h>
 #include "knod_amdgpu_insn.h"
 #include "../../../../../../net/core/devmem.h"
@@ -531,6 +532,8 @@ struct knod_bpf_priv {
 	struct task_struct *worker_task;
 	struct list_head free_list_sqw;
 	struct mutex map_op_lock;
+	bool map_op_quiesce;
+	wait_queue_head_t map_op_wq;
 	/* maps awaiting deferred free by the worker */
 	struct list_head dead_maps;
 	u32 maps_tick_skip;


### PR DESCRIPTION
Two commits. The blob half of the second is TaeheeYoo/knod-blob#20; both trees
need it.

## Maps were in uncached memory

The map BOs asked for COHERENT, which `gmc_v11_0_get_vm_pte` turns into
`MTYPE_UC`: every load of a map goes past L0, L1 and L2 to memory. The loads that
must miss the caches a compute unit does not share already say so themselves —
the routines carry `glc` and `dlc` — so what the flag added was to stop the one
cache that would have helped, on the one access a program makes which is neither
uniform nor sequential.

gfx1100, kondor, with the cycle probe:

| | COHERENT | cached |
|---|---|---|
| prologue | 20,226 | **20,926** |
| program | 56,426 | **25,666** |
| epilogue | 707 | 679 |
| dispatch latency | 391 µs | **143 µs** |

The prologue reads no map and does not move, which is what says this is the maps
and not something else. Throughput 42.5 → 53 Mpps, ~60 with `poll_mode`.

What the flag also bought was the host writing a map under a running dispatch.
The shader's writes live in L2 until the dispatch ends, a host write does not
reach those lines — a BAR write does not snoop the device's cache — and the
writeback lands on top of it. So the host writes where there is nothing to land
on: `knod_bpf_map_op_begin` asks the worker to stop submitting and waits for the
pipe to empty, after the release has written those lines back and before the next
acquire picks the host's write up.

Checked with a one-entry gate map in front of kondor's balancer: flipping it from
userspace turns the traffic off and on, and hammering it in a loop keeps working
at 32 Mpps — the drain is real and it costs what a drain costs.

## The free list disagreed with itself

The queue is a stack and the count says how deep it is: putting an element back
writes `queue[cur]` and then raises the count, so taking one has to lower the
count and read `queue[cur]`, which is what the shader does. The host read
`queue[cur]` first and lowered the count after, so it took the slot above the top
— one that was never pushed — and from the same starting count the two sides took
different elements. A shader allocation followed by a host one handed out the same
element twice.

The count also started one short, so a map held one fewer than asked for and a map
of one held nothing: its first update came back `ENOMEM`. It is read as signed
now, because the shader decrements before it knows whether there was anything
left.

## Known follow-up

`poll expire` fires more often than it did. The quiesce is the suspect — while it
waits, the worker submits nothing, so it falls through to `knod_bpf_wait_event`
and blocks rather than polling, and a dispatch already in flight can age out at
ten milliseconds. Tracked separately; it force-retires rather than losing work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)