### PR TITLE
drm/amdkfd: knod: add a 64-bit amount, not that amount times 2^32

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/kfd_knod.c
+++ b/drivers/gpu/drm/amd/amdkfd/kfd_knod.c
@@ -684,7 +684,6 @@ static int knod_alloc_one_queue(struct knod *knod, int idx,
 				struct kfd_process_device *pdd, void *ptr)
 {
 	int buf_flags = KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE |
-			KFD_IOC_ALLOC_MEM_FLAGS_COHERENT |
 			KFD_IOC_ALLOC_MEM_FLAGS_VRAM;
 	int flags = KFD_IOC_ALLOC_MEM_FLAGS_EXECUTABLE |
 		    KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE |

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -6717,11 +6717,14 @@ static void knod_bpf_emit_percpu_add(struct knod_bpf_priv *priv,
 	}
 
 	if (is_dw) {
-		/* An x2 atomic takes a consecutive pair, and a 32-bit amount
-		 * reaches the dword the host reads from the second of them.
+		struct amdgcn_param32 v_31;
+
+		/* The pair the x2 atomic adds is one number, low half first,
+		 * so a 32-bit amount goes in the low one and its sign in the
+		 * high one.
 		 */
-		knod_emit(priv, meta, v_mov_b32_e32, v_tmp_hi, v_tmp);
-		knod_emit(priv, meta, v_mov_b32_e32, v_tmp, v_zero);
+		knod_iset32(&v_31, 31);
+		knod_emit(priv, meta, v_ashrrev_i32, v_tmp_hi, v_31, v_tmp);
 		knod_emit(priv, meta, global_atomic_add_x2, v_tmp,
 			  bpf_reg64[d].lo, v_tmp, meta->insn.off, 0);
 	} else {
@@ -10465,23 +10468,20 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 				 * and put the wave's total on one lane's
 				 * element.
 				 */
-				struct amdgcn_param32 v_tmp, v_tmp_hi, v_zero;
+				struct amdgcn_param32 v_tmp, v_tmp_hi;
 
 				knod_vset32(&v_tmp, KNOD_AMDGPU_TMP_VREG0_LO);
 				knod_vset32(&v_tmp_hi,
 					    KNOD_AMDGPU_TMP_VREG0_HI);
-				knod_iset32(&v_zero, 0);
 
 				if (is_dw) {
-					/* An x2 atomic takes a consecutive
-					 * pair, and a 32-bit amount reaches the
-					 * dword the host reads from the second
-					 * of them.
+					/* The pair the x2 atomic adds is one
+					 * number, low half first.
 					 */
 					knod_emit(priv, meta, v_mov_b32_e32,
-						  v_tmp_hi, bpf_reg64[s].lo);
+						  v_tmp, bpf_reg64[s].lo);
 					knod_emit(priv, meta, v_mov_b32_e32,
-						  v_tmp, v_zero);
+						  v_tmp_hi, bpf_reg64[s].hi);
 					knod_emit(priv, meta,
 						  global_atomic_add_x2, v_tmp,
 						  bpf_reg64[d].lo, v_tmp, off,


### PR DESCRIPTION
Two unrelated one-liners that happened to be in the tree together. No blob half.

## Every 64-bit counter read 2^32 times high

`global_atomic_add_x2` takes a consecutive pair of dwords and adds them as one
number, low half first. Both sites that emit it built the pair as `{0, amount}`,
so what landed was `amount << 32`. The comment on one of them recorded the
reasoning that got it wrong — that a 32-bit amount reaches "the dword the host
reads from the second of them" — but the host reads the `u64`, and the second
dword is its top half.

kondor's stats, which is where it shows:

```
                     before                 after
total.packets    0xf7c2a399_00000000     4619661332
total.bytes      ...                   295658325248
tx.packets       0xf7c2b4fb_00000000     4619661332
```

4619661332 x 64 is exactly 295658325248, and the traffic is 64-byte packets.

The percpu path has a 32-bit amount, so it goes in the low dword and
`v_ashrrev_i32` by 31 fills the high one with its sign. The general `BPF_ATOMIC`
path has a real 64-bit source and just moves both halves.

This was invisible for as long as it was because the totals were never wrong,
only their place value — nothing about the traffic or the throughput depends on
where in the word the count sits, so it took reading the numbers as numbers.

## The context save area does not need to be uncached

Same `MTYPE_UC` story as the map BOs in #38. `kaql[idx].ctx` is the CWSR context
save area: the host allocates it, hands the queue its address, and frees it. It
never reads what is in there, so there is nothing for COHERENT to make coherent,
and it is the hardware's own spill target on a wave save.

The dma-buf packet buffers keep the flag — NIC DMA does not snoop the device's
cache, and that one has an actual reader on the other side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)