### PR TITLE
drm/amdkfd: knod: let the packet buffer be cached, and poll through a drain

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/kfd_knod.c
+++ b/drivers/gpu/drm/amd/amdkfd/kfd_knod.c
@@ -1314,7 +1314,6 @@ struct knod *knod_alloc_ctx(struct knod_dev *knodev, int queue_cnt, int id,
 			    int channels)
 {
 	int buf_flags = KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE |
-			KFD_IOC_ALLOC_MEM_FLAGS_COHERENT |
 			KFD_IOC_ALLOC_MEM_FLAGS_VRAM;
 	struct kfd_topology_device *topo_dev;
 	struct kfd_process_device *pdd;

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -2610,12 +2610,17 @@ static bool knod_bpf_poll_mode;
  */
 static u32 knod_bpf_dispatch_delay_us = 20;
 
+/* Retry the signal this often while blocked, so that missing a completion
+ * interrupt costs one dispatch rather than the whole expire budget.
+ */
+#define KNOD_BPF_WAIT_MS	1
+
 static void knod_bpf_wait_event(struct knod_bpf_priv *priv)
 {
 	struct kfd_event_data events = {
 		.event_id = priv->knod->aql_event[0].id,
 	};
-	u32 timeout_ms = knod_bpf_expire;
+	u32 timeout_ms = KNOD_BPF_WAIT_MS;
 	u32 wait_result;
 
 	knod_wait_on_events(priv->knod->process, 1, &events, true,
@@ -2732,6 +2737,7 @@ static int knod_bpf_worker(void *arg)
 	struct knod_bpf_priv *priv = arg;
 	struct knod_bpf_work_sq *sqw;
 	bool progressed;
+	bool quiesce;
 
 	while (!kthread_should_stop()) {
 		if (kthread_should_park()) {
@@ -2743,6 +2749,7 @@ static int knod_bpf_worker(void *arg)
 		knod_bpf_maps_tick(priv);
 
 		progressed = false;
+		quiesce = READ_ONCE(priv->map_op_quiesce);
 
 		rcu_read_lock_bh();
 		/* Retire completed dispatches oldest-first: the signal is
@@ -2764,7 +2771,7 @@ static int knod_bpf_worker(void *arg)
 		/* Keep the pipe full: dispatch ahead up to KNOD_BPF_INFLIGHT.
 		 * Staging self-limits, so this stops once the ring is drained.
 		 */
-		if (unlikely(READ_ONCE(priv->map_op_quiesce))) {
+		if (unlikely(quiesce)) {
 			if (!priv->inflight_cnt)
 				wake_up(&priv->map_op_wq);
 		} else {
@@ -2777,16 +2784,15 @@ static int knod_bpf_worker(void *arg)
 			knod_bpf_schedule_pending_napi(priv);
 			usleep_range(100, 200);
 		} else if (!progressed) {
-			/* Room to dispatch ahead but the pacing window has not
-			 * opened yet: spin so the next submit fires on time and
-			 * a completion is retired the instant it lands.  Block
-			 * on the event only when the pipe is full (nothing to
-			 * submit) or spacing is disabled.
+			/* Block on the event only when there is nothing else to
+			 * do with the time: not while a drain is waiting on the
+			 * pipe, and not while the pacing window is still open
+			 * and the next submit is due.
 			 */
-			if (priv->inflight_cnt < KNOD_BPF_INFLIGHT &&
-			    ktime_before(ktime_get(), priv->next_dispatch_time))
+			if (quiesce || knod_bpf_poll_mode)
 				cpu_relax();
-			else if (knod_bpf_poll_mode)
+			else if (priv->inflight_cnt < KNOD_BPF_INFLIGHT &&
+				 ktime_before(ktime_get(), priv->next_dispatch_time))
 				cpu_relax();
 			else
 				knod_bpf_wait_event(priv);


### PR DESCRIPTION
Two commits, no blob half. The second follows the first only because both
were in the tree at once; they are independent.

## The drain slept through itself

`knod_bpf_map_op_begin` stops the worker submitting and waits for the pipe to
empty. While it waits there is nothing to submit, so `progressed` stays false,
the twenty-microsecond pacing window closes, and the worker falls through to
`knod_bpf_wait_event` — it blocks on the completion interrupt at the one moment
when its only remaining job is to retire what is in flight as quickly as it can.

The wait was also handed the expire time as its own timeout, so the sleep ended
exactly when the oldest dispatch aged out. A missed wakeup could not cost a late
retire; it cost a `poll expire`, every time. That is why the warning arrived with
the quiesce in #38 and not before — before it, the worker was almost always
submitting, so it rarely reached the blocking branch at all.

Spin through a drain, and cap the blocking wait at a millisecond so a missed
interrupt is worth one dispatch rather than the whole ten.

Measured: `poll expire` goes from frequent to rare, not to zero. What survives has
to be a different cause, since the worker now re-polls the signal every
millisecond and a dispatch must genuinely miss its ten to age out. GFXOFF is the
suspect — a map op is the only thing in this workload that leaves the GPU idle,
and knod lost its GFXOFF hold-off. Tracked separately.

## The packet buffer was uncached

Same `MTYPE_UC` story as the maps in #38 and the context save area in #39, on the
one buffer where it costs the most: the per-channel dma-buf the NIC receives
into. Every packet byte a program touches was going past L0, L1 and L2 to memory.

Nothing needs the flag. Every dispatch already carries a system-scope acquire and
release, and the command processor turns a system-scope acquire into a GL2
invalidate — the same mechanism the cached maps depend on, and the one the gate
map test in #38 confirmed end to end when flipping a map from userspace turned
traffic off and on. Each party is on the right side of a dispatch boundary
already:

| | |
|---|---|
| NIC writes over P2P | the data write precedes the completion the driver reads before staging the descriptor |
| shader reads | the acquire's GL2 invalidate |
| shader writes, via `adjust_head` or encap | the release writes L2 back at dispatch end |
| SDMA d2h copy, host mapping | both read after the completion signal, so after that release |

The worry worth naming — that a later dispatch's acquire could discard a running
dispatch's dirty L2 lines — is already answered by the shader-written hash map
running at 3228 `cache_miss` in 508M packets. If invalidation ate dirty lines,
that number would not be small.

The one thing that would break the ordering above is PCIe relaxed ordering on the
NIC letting a data write pass the completion write. Worth a look at `RlxdOrd` on
the function if anything ever does come back stale.

## What this opens up

`pkt_cache` holds packet bytes in v68-v127 so a program does not re-load them —
a software cache built because this buffer was uncached. With `pkt_cache` off and
only the maps cached the branch already reached 43 Mpps, where it used to be far
lower. If the hardware L0 can do that job, sixty VGPRs come back, and VGPRs are
allocated per wave. Tracked separately, along with the larger version of the same
question: the BPF stack is v128-v255, and the JIT declares all 256 VGPRs no matter
what the program uses, while `max_stack_off` is computed and then read by nobody.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
