### PR TITLE
drm/amdkfd: knod: let the BPF stack live in scratch, and bring scratch up to do it

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/kfd_knod.c
+++ b/drivers/gpu/drm/amd/amdkfd/kfd_knod.c
@@ -504,7 +504,11 @@ static void knod_init_aql_queue(struct knod *knod, int qid, int idx)
 		knod->kaql[idx].scratch->gaddr;
 	amd_queue->scratch_backing_memory_byte_size =
 		knod->kaql[idx].scratch->size;
-	amd_queue->scratch_wave64_lane_byte_size = 64;
+	amd_queue->scratch_wave64_lane_byte_size = KNOD_SCRATCH_BYTES_PER_LANE;
+	amd_queue->compute_tmpring_size =
+		(knod->scratch_waves & KNOD_TMPRING_WAVES_MASK) |
+		((knod->scratch_wavesize & KNOD_TMPRING_WAVESIZE_MASK) <<
+		 KNOD_TMPRING_WAVESIZE_SHIFT);
 
 	amd_queue->queue_properties.is_ptr64 = 1;
 	amd_queue->queue_properties.enable_trap_handler_debug_sgprs = 0;
@@ -679,6 +683,47 @@ static void knod_destroy_one_queue(struct knod *knod, int idx)
 	knod_free_mem(knod, knod->kaql[idx].scratch);
 }
 
+/* The scratch ring holds one slot per wave the device can keep resident, and
+ * the command processor finds a wave's slot from COMPUTE_TMPRING_SIZE.  This
+ * is what ROCr works out in AqlQueue::FillComputeTmpRingSize_Gfx11() and the
+ * sizing above it; gfx11 counts the waves per engine rather than in total, and
+ * measures both fields in 256-byte granules where earlier parts used 1 KB.
+ */
+static size_t knod_scratch_ring_size(struct knod *knod,
+				     struct kfd_topology_device *topo_dev)
+{
+	u32 slots_per_cu = topo_dev->node_props.max_slots_scratch_cu;
+	u32 simd_per_cu = topo_dev->node_props.simd_per_cu;
+	u32 engines = topo_dev->node_props.array_count;
+	u32 granule, per_lane, slots, waves, cus;
+	size_t size;
+
+	knod->scratch_wavesize = 0;
+	knod->scratch_waves = 0;
+
+	if (!slots_per_cu || !simd_per_cu || !engines)
+		return 0;
+
+	granule = knod->isa_version >= 11 ? 256 : 1024;
+	cus = topo_dev->node_props.simd_count / simd_per_cu;
+	per_lane = roundup(KNOD_SCRATCH_BYTES_PER_LANE,
+			   granule / KNOD_WAVE_LANES);
+	slots = roundup(cus, engines) * slots_per_cu;
+	size = (size_t)per_lane * slots * KNOD_WAVE_LANES;
+
+	knod->scratch_wavesize = DIV_ROUND_UP(KNOD_WAVE_LANES * per_lane,
+					      granule);
+	waves = size / ((size_t)knod->scratch_wavesize * granule);
+	if (knod->isa_version >= 11)
+		waves /= engines;
+	knod->scratch_waves = min(waves, slots);
+
+	/* A VRAM buy that is not a power of two has been seen to walk over the
+	 * mapping of the buffer before it.
+	 */
+	return roundup_pow_of_two(size);
+}
+
 static int knod_alloc_one_queue(struct knod *knod, int idx,
 				struct kfd_topology_device *topo_dev,
 				struct kfd_process_device *pdd, void *ptr)
@@ -692,6 +737,7 @@ static int knod_alloc_one_queue(struct knod *knod, int idx,
 	struct amd_signal *queue_signal;
 	struct amd_queue *amd_queue;
 	struct queue_properties qp;
+	size_t scratch_size;
 	u32 total_cwsr_size;
 	int err;
 
@@ -758,11 +804,20 @@ static int knod_alloc_one_queue(struct knod *knod, int idx,
 		goto err_mem;
 	}
 
+	scratch_size = knod_scratch_ring_size(knod, topo_dev);
+	if (!scratch_size) {
+		knod_err(" no scratch geometry from topology\n");
+		err = -EINVAL;
+		goto err_mem;
+	}
+
+	/* No COHERENT: that is MTYPE_UC, and a stack that cannot be cached is
+	 * the whole reason not to put one here.
+	 */
 	knod->kaql[idx].scratch = knod_alloc_mem(knod,
-		PAGE_SIZE << 5,
+		scratch_size,
 		KFD_IOC_ALLOC_MEM_FLAGS_VRAM |
-		KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE |
-		KFD_IOC_ALLOC_MEM_FLAGS_COHERENT);
+		KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE);
 	if (IS_ERR(knod->kaql[idx].scratch)) {
 		err = PTR_ERR(knod->kaql[idx].scratch);
 		knod->kaql[idx].scratch = NULL;

--- a/drivers/gpu/drm/amd/amdkfd/knod/kfd_knod.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/kfd_knod.h
@@ -103,6 +103,19 @@ enum knod_feature {
 
 #define NR_AQL_RING 16384
 #define AQL_STRUCT_SIZE 128
+
+/* Every knod shader is wave64; the wave32 paths are dead. */
+#define KNOD_WAVE_LANES			64
+
+/* What a lane gets of the private segment.  It holds the BPF stack and
+ * nothing else, so this is that stack, and the scratch ring is sized from it.
+ */
+#define KNOD_SCRATCH_BYTES_PER_LANE	512
+
+/* COMPUTE_TMPRING_SIZE, same layout gfx9 through gfx11 (gc_11_0_0_sh_mask.h) */
+#define KNOD_TMPRING_WAVES_MASK		0xfff
+#define KNOD_TMPRING_WAVESIZE_MASK	0x7fff
+#define KNOD_TMPRING_WAVESIZE_SHIFT	12
 /* Machine code built for this GPU somewhere other than here.  One file per
  * thing that wants some - the core's own kernel, the BPF JIT's routines - so
  * that a file arriving late or not at all is that consumer's problem and no
@@ -172,6 +185,11 @@ struct knod {
 	 * print can be fed straight to a disassembler.
 	 */
 	u32 gfx_target_version;
+	/* COMPUTE_TMPRING_SIZE, worked out where the ring is sized so the two
+	 * cannot drift: how big a wave's slot is, and how many slots there are.
+	 */
+	u32 scratch_wavesize;
+	u32 scratch_waves;
 	/* NAPIs */
 	int channels;
 	struct kfd_process *process;

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_amdgpu_insn.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_amdgpu_insn.h
@@ -1484,6 +1484,37 @@ static inline void emit_global_load_dword(int version, struct amdgcn_insn *insn,
 	}
 }
 
+/* Scratch is gfx11 only for now: nothing below it has been brought up, and the
+ * one caller refuses to emit these on an older part.
+ */
+static inline void emit_scratch_load_dword(int version,
+					   struct amdgcn_insn *insn,
+					   struct amdgcn_param32 dst, short off)
+{
+	WARN_ON(dst.type != AMDGCN_PARAM_TYPE_VGPR);
+	if (version == 11) {
+		insn->size = emit_gfx11_scratch_load_dword(&insn->gfx11, dst,
+							   off);
+		insn->type = AMDGCN_INSN_TYPE_FLAT;
+	} else {
+		WARN_ON_ONCE(1);
+	}
+}
+
+static inline void emit_scratch_store_dword(int version,
+					    struct amdgcn_insn *insn,
+					    struct amdgcn_param32 src, short off)
+{
+	WARN_ON(src.type != AMDGCN_PARAM_TYPE_VGPR);
+	if (version == 11) {
+		insn->size = emit_gfx11_scratch_store_dword(&insn->gfx11, src,
+							    off);
+		insn->type = AMDGCN_INSN_TYPE_FLAT;
+	} else {
+		WARN_ON_ONCE(1);
+	}
+}
+
 static inline void emit_global_load_dwordx2(int version,
 				     struct amdgcn_insn *insn,
 				     struct amdgcn_param32 dst,

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -191,6 +191,14 @@ static_assert(sizeof(struct knod_bpf_subparam_obj) ==
 #define KNOD_AMDGPU_STACK_VREG0		128
 #define KNOD_AMDGPU_STACK_VREG_MAX	255 /* 128 ~ 255 vgprs are available */
 
+/* With the stack in scratch, v130 upwards is free for whoever wants it - the
+ * wave still declares all 256 either way.  These two are the pair the load and
+ * store helpers work a slot through, kept at the bottom of that range so that
+ * what is free stays one contiguous run.
+ */
+#define KNOD_AMDGPU_STACK_WIN_VREG0	128
+#define KNOD_AMDGPU_STACK_WIN_VREG1	129
+
 /* One VGPR holds four bytes of packet, so what the cache can hold is decided
  * by how many VGPRs sit between its base and the stack.
  */
@@ -432,6 +440,36 @@ module_param_named(cycle_probe, knod_bpf_cycle_probe, int, 0600);
 unsigned int knod_bpf_jit_engine = 1;
 MODULE_PARM_DESC(jit_engine, "0=kernel, 1=blob(Default)");
 module_param_named(jit_engine, knod_bpf_jit_engine, int, 0600);
+
+/* Where the BPF stack lives.  Cached means VGPRs, one per dword, which is the
+ * whole upper half of the register file.  Uncached spends a scratch access per
+ * stack touch and frees that half for something else to hold; on its own it
+ * only costs, so it is worth turning on once there is a use for what it frees.
+ *
+ * The blob's routines are built against the register form, and nothing below
+ * gfx11 has scratch brought up, so both force it back on.
+ */
+unsigned int knod_bpf_stack_cache = 1;
+MODULE_PARM_DESC(stack_cache, "BPF stack in 1=VGPRs(Default), 0=scratch");
+module_param_named(stack_cache, knod_bpf_stack_cache, int, 0600);
+
+static bool knod_stack_in_scratch(int isa_version)
+{
+	if (knod_bpf_stack_cache)
+		return false;
+
+	if (knod_bpf_jit_engine || isa_version != 11) {
+		pr_warn_once("knod_bpf: stack_cache=0 wants jit_engine=0 on gfx11; keeping the stack in registers\n");
+		return false;
+	}
+
+	return true;
+}
+
+static bool knod_bpf_stack_in_scratch(struct knod_bpf_priv *priv)
+{
+	return knod_stack_in_scratch(priv->isa_version);
+}
 
 /* Whether a workgroup takes the whole WGP.  In CU mode its waves sit on one CU
  * and share that CU's cache; in WGP mode they spread over both and reach more
@@ -835,7 +873,8 @@ static void kfd_kernel_rdna_init(struct knod *knod)
 	kernel_code->compute_pgm_rsrc1.mem_ordered = 1;
 	kernel_code->compute_pgm_rsrc1.fwd_progress = 0;
 
-	kernel_code->compute_pgm_rsrc2.enable_private_segment = 0;
+	kernel_code->compute_pgm_rsrc2.enable_private_segment =
+		knod_stack_in_scratch(knod->isa_version);
 	kernel_code->compute_pgm_rsrc2.user_sgpr_count = 14; /* 4+2+2+2+2+2 */
 	kernel_code->compute_pgm_rsrc2.enable_trap_handler = 0;
 	kernel_code->compute_pgm_rsrc2.enable_sgpr_workgroup_id_x = 1;
@@ -5885,7 +5924,58 @@ static void knod_bpf_xdp_adjust_tail(struct knod_bpf_priv *priv,
  * is hashed a dword at a time and the host hashed only the key, so anything
  * carried in past its end lands the two on different buckets.
  */
+/* Both accessors below reach exactly two consecutive dwords, cache[off / 4]
+ * and the one after it, so a two-register window is all it takes to run them
+ * unchanged against a stack that lives in scratch.  Returning the window
+ * biased by the dword index is what lets the bodies keep indexing absolutely.
+ */
+static struct amdgcn_param32 *knod_bpf_stack_win(struct knod_bpf_priv *priv,
+						 struct knod_insn_meta *meta,
+						 struct amdgcn_param32 *win,
+						 int off, bool load)
+{
+	knod_vset32(&win[0], KNOD_AMDGPU_STACK_WIN_VREG0);
+	knod_vset32(&win[1], KNOD_AMDGPU_STACK_WIN_VREG1);
+
+	if (load) {
+		knod_emit(priv, meta, scratch_load_dword, win[0], off & ~3);
+		knod_emit(priv, meta, scratch_load_dword, win[1],
+			  (off & ~3) + 4);
+		knod_emit(priv, meta, s_waitcnt_vmcnt);
+	}
+
+	return win - (off / 4);
+}
+
+static void knod_bpf_stack_win_flush(struct knod_bpf_priv *priv,
+				     struct knod_insn_meta *meta,
+				     struct amdgcn_param32 *win, int off)
+{
+	knod_emit(priv, meta, scratch_store_dword, win[0], off & ~3);
+	knod_emit(priv, meta, scratch_store_dword, win[1], (off & ~3) + 4);
+}
+
+static void __knod_bpf_load_size32(struct knod_bpf_priv *priv,
+				   struct knod_insn_meta *meta,
+				   struct amdgcn_param32 dst,
+				   struct amdgcn_param32 *cache,
+				   int size, int off);
+
 static void knod_bpf_load_size32(struct knod_bpf_priv *priv,
+				 struct knod_insn_meta *meta,
+				 struct amdgcn_param32 dst,
+				 struct amdgcn_param32 *cache,
+				 int size, int off)
+{
+	struct amdgcn_param32 win[2];
+
+	if (cache == stack && knod_bpf_stack_in_scratch(priv))
+		cache = knod_bpf_stack_win(priv, meta, win, off, true);
+
+	__knod_bpf_load_size32(priv, meta, dst, cache, size, off);
+}
+
+static void __knod_bpf_load_size32(struct knod_bpf_priv *priv,
 				 struct knod_insn_meta *meta,
 				 struct amdgcn_param32 dst,
 				 /* packet or stack */
@@ -8163,7 +8253,34 @@ static void knod_bpf_map_delete_array(struct knod_bpf_priv *priv,
 		knod_map_bypass_l0(priv, meta, first_mem);
 }
 
+static void __knod_bpf_store_cache_size(struct knod_bpf_priv *priv,
+					struct knod_insn_meta *meta,
+					struct amdgcn_param64 *src,
+					struct amdgcn_param32 *cache,
+					int size, int off);
+
 static void knod_bpf_store_cache_size(struct knod_bpf_priv *priv,
+				      struct knod_insn_meta *meta,
+				      struct amdgcn_param64 *src,
+				      struct amdgcn_param32 *cache,
+				      int size, int off)
+{
+	struct amdgcn_param32 win[2];
+
+	if (cache != stack || !knod_bpf_stack_in_scratch(priv)) {
+		__knod_bpf_store_cache_size(priv, meta, src, cache, size, off);
+		return;
+	}
+
+	/* Read-modify-write even when the body writes only one of the pair:
+	 * the sub-dword cases merge into what is already there.
+	 */
+	cache = knod_bpf_stack_win(priv, meta, win, off, true);
+	__knod_bpf_store_cache_size(priv, meta, src, cache, size, off);
+	knod_bpf_stack_win_flush(priv, meta, win, off);
+}
+
+static void __knod_bpf_store_cache_size(struct knod_bpf_priv *priv,
 				     struct knod_insn_meta *meta,
 				     struct amdgcn_param64 *src,
 				     /* packet or stack */

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -563,7 +563,7 @@ static void knod_bpf_fill_dispatch(struct knod_bpf_priv *priv,
 	p->workgroup_size_x = knod_bpf_workgroups;
 	p->grid_size_x = priv->batch_size;
 	p->grid_size_y = param->nr_queues;
-	p->private_segment_size = 8192;
+	p->private_segment_size = KNOD_SCRATCH_BYTES_PER_LANE;
 	p->group_segment_size = KNOD_BPF_LDS_SIZE;
 	p->kernel_object =
 		(u64)priv->knod->kernels[READ_ONCE(priv->active_idx)]->gaddr;
@@ -699,7 +699,7 @@ static void kfd_kernel_gfx9_init(struct knod *knod)
 	struct kernel_descriptor *kernel_code = knod->kernels[0]->kaddr;
 
 	kernel_code->group_segment_fixed_size = 0;
-	kernel_code->private_segment_fixed_size = 8192;
+	kernel_code->private_segment_fixed_size = KNOD_SCRATCH_BYTES_PER_LANE;
 	kernel_code->kernarg_size = 64;
 	kernel_code->kernel_code_entry_byte_offset = 1024;
 
@@ -804,7 +804,7 @@ static void kfd_kernel_rdna_init(struct knod *knod)
 	struct kernel_descriptor *kernel_code = knod->kernels[0]->kaddr;
 
 	kernel_code->group_segment_fixed_size = 0;
-	kernel_code->private_segment_fixed_size = 8192;
+	kernel_code->private_segment_fixed_size = KNOD_SCRATCH_BYTES_PER_LANE;
 	kernel_code->kernarg_size = 64;
 	kernel_code->kernel_code_entry_byte_offset = 1024;
 

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -446,8 +446,10 @@ module_param_named(jit_engine, knod_bpf_jit_engine, int, 0600);
  * stack touch and frees that half for something else to hold; on its own it
  * only costs, so it is worth turning on once there is a use for what it frees.
  *
- * The blob's routines are built against the register form, and nothing below
- * gfx11 has scratch brought up, so both force it back on.
+ * Either engine will do.  The stack is the JIT's own: a blob routine reaches
+ * no further than v69, because the stack has always lived above that and a
+ * routine standing on it would have broken the default long ago.  Nothing
+ * below gfx11 has scratch brought up, though.
  */
 unsigned int knod_bpf_stack_cache = 1;
 MODULE_PARM_DESC(stack_cache, "BPF stack in 1=VGPRs(Default), 0=scratch");
@@ -458,8 +460,8 @@ static bool knod_stack_in_scratch(int isa_version)
 	if (knod_bpf_stack_cache)
 		return false;
 
-	if (knod_bpf_jit_engine || isa_version != 11) {
-		pr_warn_once("knod_bpf: stack_cache=0 wants jit_engine=0 on gfx11; keeping the stack in registers\n");
+	if (isa_version != 11) {
+		pr_warn_once("knod_bpf: stack_cache=0 needs gfx11; keeping the stack in registers\n");
 		return false;
 	}
 
@@ -1054,6 +1056,14 @@ static void knod_submit_bpf(struct knod_bpf_priv *priv,
 	sqw->expire = jiffies + msecs_to_jiffies(knod_bpf_expire);
 	if (static_branch_unlikely(&knod_stats_key)) {
 		sqw->dispatch_time = ktime_get();
+
+		/* Rate is packets over the time packets were flowing, not over
+		 * however long ago the counters were reset.
+		 */
+		if (!stats->first_dispatch_ns)
+			stats->first_dispatch_ns =
+				ktime_to_ns(sqw->dispatch_time);
+		stats->last_dispatch_ns = ktime_to_ns(sqw->dispatch_time);
 
 		stats->backlogs_total += sqw->backlogs;
 		for (i = 0; i < KNOD_BL_BUCKETS - 1; i++) {
@@ -2750,6 +2760,7 @@ static bool knod_bpf_poll_complete(struct knod_bpf_priv *priv,
 	}
 
 	if (time_after(jiffies, sqw->expire)) {
+		priv->stats.expire_count++;
 		pr_warn_ratelimited("knod_bpf: poll expire (sigval=%lld signal=%lld expire_ms=%u)\n",
 			sqw->sigval, READ_ONCE(signal->value), knod_bpf_expire);
 		knod_bpf_record_completion(priv, sqw);
@@ -12104,14 +12115,22 @@ static int knod_stats_show(struct seq_file *s, void *unused)
 	struct knod_bpf_priv *priv = s->private;
 	u64 p50 = 0, p99 = 0, p999 = 0, acc;
 	struct knod_bpf_stats *stats;
-	u64 ccnt, dcnt, elapsed, end, mpps;
+	u32 gfx = priv->knod->gfx_target_version;
+	u64 ccnt, dcnt, elapsed, wall, end, mpps;
 	int i;
 
 	stats = &priv->stats;
 	ccnt = stats->completion_count;
 	dcnt = stats->dispatch_count;
 	end = stats->stop_ns ? stats->stop_ns : ktime_get_ns();
-	elapsed = stats->start_ns ? end - stats->start_ns : 0;
+	wall = stats->start_ns ? end - stats->start_ns : 0;
+
+	/* Rate over the time dispatches were actually going out.  Measured from
+	 * the reset instead, an idle link before the traffic started reads as
+	 * throughput the device failed to deliver.
+	 */
+	elapsed = stats->last_dispatch_ns > stats->first_dispatch_ns ?
+		  stats->last_dispatch_ns - stats->first_dispatch_ns : 0;
 
 	seq_printf(s, "enabled:             %s\n",
 		   static_branch_unlikely(&knod_stats_key) ? "yes" : "no");
@@ -12127,10 +12146,36 @@ static int knod_stats_show(struct seq_file *s, void *unused)
 		   (int)knod_bpf_workgroups : 0);
 	seq_printf(s, "batch:               %d per queue, %d total\n",
 		   priv->batch_size, priv->batch_size * priv->nr_works);
+	seq_printf(s, "waves:               %d per queue, %d total\n",
+		   DIV_ROUND_UP(priv->batch_size, KNOD_WAVE_LANES),
+		   DIV_ROUND_UP(priv->batch_size, KNOD_WAVE_LANES) *
+		   priv->nr_works);
+	seq_printf(s, "pkt_cache:           %s\n",
+		   knod_bpf_pkt_cache ? "vgpr" : "off");
+	/* What is in force, and when that is not what was asked for, say so:
+	 * reporting only the effective value turns a refusal into a mystery.
+	 */
+	seq_printf(s, "stack_cache:         %s%s\n",
+		   knod_bpf_stack_in_scratch(priv) ? "scratch" : "vgpr",
+		   !knod_bpf_stack_cache && !knod_bpf_stack_in_scratch(priv) ?
+		   " (scratch asked for and refused)" : "");
+	seq_printf(s, "mcpu:                gfx%u%u%u\n",
+		   gfx / 10000, (gfx / 100) % 100, gfx % 100);
+	seq_printf(s, "jit_engine:          %s\n",
+		   knod_bpf_jit_engine ? "blob" : "kernel");
+	seq_printf(s, "poll_mode:           %s\n",
+		   knod_bpf_poll_mode ? "spin" : "event");
+	seq_printf(s, "dispatch_delay_us:   %u\n",
+		   READ_ONCE(knod_bpf_dispatch_delay_us));
+	seq_printf(s, "queue_expire_ms:     %u\n", knod_bpf_expire);
+	seq_printf(s, "wgp:                 %s\n", knod_bpf_wgp ? "yes" : "no");
+	seq_printf(s, "cycle_probe:         %u%s\n", knod_bpf_cycle_probe,
+		   knod_bpf_cycle_probe ? " (costs throughput)" : "");
 
+	seq_printf(s, "elapsed_ms:          %llu\n", wall / NSEC_PER_MSEC);
 	if (elapsed) {
 		mpps = stats->backlogs_total * 100000ULL / elapsed;
-		seq_printf(s, "elapsed_ms:          %llu\n",
+		seq_printf(s, "active_ms:           %llu\n",
 			   elapsed / NSEC_PER_MSEC);
 		seq_printf(s, "dispatch_per_s:      %llu\n",
 			   dcnt * NSEC_PER_SEC / elapsed);
@@ -12145,6 +12190,8 @@ static int knod_stats_show(struct seq_file *s, void *unused)
 	seq_printf(s, "max_ns:              %llu\n", stats->dispatch_max_ns);
 	seq_printf(s, "backlogs_avg:        %llu\n",
 		   dcnt ? stats->backlogs_total / dcnt : 0);
+	/* Force-retired without ever signalling.  Only dmesg used to say. */
+	seq_printf(s, "expired:             %llu\n", stats->expire_count);
 
 	seq_puts(s, "\nbacklogs histogram:\n");
 	for (i = 0; i < KNOD_BL_BUCKETS; i++)
@@ -12217,10 +12264,10 @@ no_cycles:
 	/* The grid asks for groups_per_queue workgroups per queue; this says how
 	 * many units they actually reached.
 	 *
-	 * A blob without the probe leaves the field it reads at zero, which
-	 * lands every packet in slot 0 and reads exactly like the answer this
-	 * was built to look for - one unit doing everything.  So say which of
-	 * the two it is rather than let the shape of the output decide.
+	 * Nothing emits the HW_ID read any more, on either engine, so the field
+	 * this counts is always zero - which lands every packet in slot 0 and
+	 * reads exactly like the answer it was built to look for, one unit doing
+	 * everything.  Say so rather than let the shape of the output decide.
 	 */
 	for (i = 0, acc = 0; i < KNOD_HWID_SLOTS; i++)
 		if (stats->hwid_hist[i])
@@ -12228,7 +12275,7 @@ no_cycles:
 
 	if (acc == 1 && stats->hwid_hist[0]) {
 		seq_puts(s, "\n--- compute units ---\n");
-		seq_puts(s, "units used:          (blob has no HW_ID probe)\n");
+		seq_puts(s, "units used:          (no HW_ID probe emitted)\n");
 	} else if (acc) {
 		seq_puts(s, "\n--- compute units ---\n");
 		seq_printf(s, "units on device:     %llu\n", acc);
@@ -12266,6 +12313,8 @@ static ssize_t knod_stats_enable_write(struct file *file,
 	if (val) {
 		priv->stats.start_ns = ktime_get_ns();
 		priv->stats.stop_ns = 0;
+		priv->stats.first_dispatch_ns = 0;
+		priv->stats.last_dispatch_ns = 0;
 		static_branch_enable(&knod_stats_key);
 	} else {
 		static_branch_disable(&knod_stats_key);

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
@@ -467,6 +467,9 @@ struct knod_bpf_stats {
 	 * depth, which is how more than one wrong number got believed.
 	 */
 	u64 start_ns;
+	u64 expire_count;
+	u64 first_dispatch_ns;
+	u64 last_dispatch_ns;
 	u64 stop_ns;		/* 0 while still running */
 
 	u64 dispatch_total_ns;

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_gfx11_insn.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_gfx11_insn.h
@@ -2341,6 +2341,62 @@ DEFINE_GFX11_GLOBAL_ST(global_store_dwordx4, GFX11_GLOBAL_STORE_B128)
 
 #undef DEFINE_GFX11_GLOBAL_ST
 
+/* --- SCRATCH ---
+ * Neither VADDR nor SADDR, so the address is the wave's own scratch base plus
+ * the immediate.  The hardware interleaves lanes within that, which is what
+ * makes a wave reading one stack slot a contiguous read of memory rather than
+ * one cache line per lane.
+ */
+#define DEFINE_GFX11_SCRATCH_LD(name, opcode)				\
+static inline u32 emit_gfx11_##name(union amdgcn_gfx11_insn *insn,	\
+				    struct amdgcn_param32 dst, short off) \
+{									\
+	insn->flat.offset = off;					\
+	insn->flat.dlc = 0;						\
+	insn->flat.glc = 0;						\
+	insn->flat.slc = 0;						\
+	insn->flat.seg = GFX11_FLAT_SEG_SCRATCH;			\
+	insn->flat.op = opcode;						\
+	insn->flat.dummy1 = 0;						\
+	insn->flat.encoding = GFX11_FLAT_ENCODING;			\
+	insn->flat.addr = 0;						\
+	insn->flat.data = 0;						\
+	insn->flat.saddr = GFX11_FLAT_SADDR_NULL;			\
+	insn->flat.sve = 0;						\
+	insn->flat.vdst = dst.v;					\
+	return 8;							\
+}
+
+DEFINE_GFX11_SCRATCH_LD(scratch_load_dword,   GFX11_SCRATCH_LOAD_B32)
+DEFINE_GFX11_SCRATCH_LD(scratch_load_dwordx2, GFX11_SCRATCH_LOAD_B64)
+
+#undef DEFINE_GFX11_SCRATCH_LD
+
+#define DEFINE_GFX11_SCRATCH_ST(name, opcode)				\
+static inline u32 emit_gfx11_##name(union amdgcn_gfx11_insn *insn,	\
+				    struct amdgcn_param32 src, short off) \
+{									\
+	insn->flat.offset = off;					\
+	insn->flat.dlc = 0;						\
+	insn->flat.glc = 0;						\
+	insn->flat.slc = 0;						\
+	insn->flat.seg = GFX11_FLAT_SEG_SCRATCH;			\
+	insn->flat.op = opcode;						\
+	insn->flat.dummy1 = 0;						\
+	insn->flat.encoding = GFX11_FLAT_ENCODING;			\
+	insn->flat.addr = 0;						\
+	insn->flat.data = src.v;					\
+	insn->flat.saddr = GFX11_FLAT_SADDR_NULL;			\
+	insn->flat.sve = 0;						\
+	insn->flat.vdst = 0;						\
+	return 8;							\
+}
+
+DEFINE_GFX11_SCRATCH_ST(scratch_store_dword,   GFX11_SCRATCH_STORE_B32)
+DEFINE_GFX11_SCRATCH_ST(scratch_store_dwordx2, GFX11_SCRATCH_STORE_B64)
+
+#undef DEFINE_GFX11_SCRATCH_ST
+
 #define DEFINE_GFX11_GLOBAL_ATOMIC(name, opcode)			\
 static inline u32 emit_gfx11_global_atomic_##name(			\
 					union amdgcn_gfx11_insn *insn,	\


### PR DESCRIPTION
Three commits. No blob half — the blob turns out to need nothing, which is
part of the story below.

## The BPF stack was the upper half of the register file

A dword of BPF stack is a VGPR, v128 through v255. What that costs is not the
registers so much as what they could have held instead: past the packet cache,
at 232 bytes, a program reaching further into the packet goes to memory for it,
and packet memory is the one place caching helps least. The stack is the
opposite — the verifier rejects a read of an uninitialised slot, so every slot
is written before it is read, nothing carries from one dispatch to the next, and
it needs no coherence of any kind. It is the one thing here that can live in
cached memory with nothing to reason about.

So `stack_cache=0` puts it in scratch, where the hardware interleaves lanes so a
wave reading one slot reads memory contiguously rather than a cache line per
lane, and leaves v130 upwards for whoever wants it. `stack_cache=1` stays the
default and changes nothing.

Both accessors reach exactly `cache[off / 4]` and the one after it, so a
two-register window runs their sub-dword bit work unchanged: load the pair, call
the body, and for a store write it back. Stores read first even when the body
writes one of the two, because the sub-dword cases merge into what is there.

**On its own this only costs.** Nothing yet uses what it frees; the point is the
packet cache growing into it, which is separate.

## Nothing had ever asked scratch for anything

So none of the setup was right, and each part was fatal on its own.

`compute_tmpring_size` **was never written at all** — `kfd_hsa.h` declares it and
knod fills every field around it. The zeroed BO left WAVESIZE and WAVES at zero:
a wave's slot is nothing and the CP has nowhere to put it. The ring was 128 KB
against a wave64 dispatch wanting 84 MB, and the 8192-byte lane that implied was
itself sixteen times the 512 the stack actually is. The ring also asked for
COHERENT, which is `MTYPE_UC` — a stack that cannot be cached being the whole
reason not to put one in memory.

The geometry is worked out where the ring is bought, from topology rather than
constants, following ROCr's `AqlQueue::FillComputeTmpRingSize_Gfx11()`. gfx11
differs from earlier parts twice over: it counts waves per engine rather than in
total, and measures both fields in 256-byte granules where gfx9 and gfx10 used
1 KB.

Checked against LLVM rather than assumed. A gfx1100 kernel that spills emits its
accesses in the offset-only form this encodes, with no prologue arming
FLAT_SCRATCH — which is what says gfx11 hands it to the wave already set up.
Both instructions assemble byte for byte the same as `llvm-mc`:

```
scratch_load_b32  v128, off, off offset:512  [00,02,51,dc,00,00,7c,80]
scratch_store_b32 off, v128, off offset:516  [04,02,69,dc,00,80,7c,00]
```

This also closes the standing question about the unused 8 KB reservation: not
removed, corrected.

## A run that did not say what it was

Two numbers disagreed with themselves.

The rate was packets over time since the counters were reset, which counts an
idle link as throughput the device failed to deliver. A run reporting 27.56 Mpps
was really doing 45, and the generator on the other side had been saying so all
along. It is measured between the first dispatch and the last now, with the
reset-relative figure kept beside it as `elapsed_ms` so the gap is legible rather
than silent. This is also the likelier reading of an old note that a short run
measured 47.9 and a long one 25.2 on the same settings — not a warm-up, just a
smaller share of nothing in the denominator.

And the geometry block named the workgroup size but none of the switches that
move the numbers. It now carries the engine, the target, `poll_mode`, the pacing
delay, the expire, `wgp`, and whether the cycle probe is on — that last one says
it costs throughput, because a run taken with it is not comparable to one without
and nothing in the output used to admit that. Waves are spelled out next to
lanes. Expired dispatches get a counter, having existed only as a ratelimited
warning nobody could count.

## What the better denominator showed

Same throughput from half the waves:

| | | |
|---|---|---|
| waves | 88 | **44** |
| dispatch/s | 4894 | **16492** |
| latency | 293 µs | **160 µs** |
| depth | 1.44 | **2.64** |
| throughput | ~45 | **45.34 Mpps** |

Per lane that is 21.5 ns either way, against the 22.67 ns the cost model already
carried. Geometry moves, `V` does not, and throughput is just `1/V`. With 44
wave64s on 160 SIMDs the machine is nearly empty and still delivers the same
number, so whatever the ceiling is, it is not the GPU.

## The refusal on blobs is lifted

The first commit refused to do this under the blob engine. That was written
without checking; the check says a blob routine reaches no further than v69,
and the stack has always lived at v128, so a routine standing on it would have
broken the default engine long ago. Confirmed running: `jit_engine: blob` with
`stack_cache: scratch`.

Please read the first commit message with that in mind — its claim about blobs
is wrong and the third commit says so. It is left in place rather than rewritten
because the history was already built.

When scratch is asked for and refused anyway the geometry line now says so,
rather than reporting the effective value alone and leaving a set parameter
looking ignored — which is exactly how this was caught.

## Still gfx11 only

gfx9 and gfx10 both need the per-wave scratch offset in a system SGPR, and it
lands on `TMP_SREG0_LO`. Those numbers are published to the blobs through uapi,
so bringing the other two generations in means shifting the map and rebuilding
every blob. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
