### PR TITLE
drm/amdkfd: knod: reserve s16 and s17 for the scratch wave offset

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -282,20 +282,23 @@ static_assert(sizeof(struct knod_bpf_subparam_obj) ==
  *+--------+--------------------------------------+---+---+
  *|  PSB   | USER SGPRs (disp/queue/karg/id/flat) |WGX|QID|
  *+--------+--------------------------------------+---+---+
- *+----------------+------+---+---+------+------+-----------+--------+
- *|   s[16:27]     |s28:29|s30|s31|s32:33|s34:35| s[36:99]  |s100:101|
- *+----------------+------+---+---+------+------+-----------+--------+
- *|TMP_SREG 0-5    |PARAM |FP | - | GFX9 | DONE | EXEC_SAVE |INITIAL |
- *|(6 x 64-bit)    |SREG  |   |   |BROKE!| MASK | 32 pairs  | EXEC   |
- *+----------------+------+---+---+------+------+-----------+--------+
+ *+---+---+----------------+------+---+---+------+------+-----------+--------+
+ *|s16|s17|   s[18:29]     |s30:31|s32|s33|s34:35|s36:37| s[38:99]  |s100:101|
+ *+---+---+----------------+------+---+---+------+------+-----------+--------+
+ *|SCR| - |TMP_SREG 0-5    |PARAM |FP | - | GFX9 | DONE | EXEC_SAVE |INITIAL |
+ *|OFF|   |(6 x 64-bit)    |SREG  |   |   |BROKE!| MASK | 32 pairs  | EXEC   |
+ *+---+---+----------------+------+---+---+------+------+-----------+--------+
  * s[102:105] exist on GFX10 and GFX11 but go unused, so that every
  * generation names the same register for the same thing.
  * Implicit: VCC = s[106:107]  EXEC = s[126:127]
  *
  * user_sgpr_count=14, same on GFX9 and GFX10.
- * enable_sgpr_private_segment_size is disabled so that workgroup_id_y
- * lands at s15 and TMP_SREG0_LO stays at s16 (keeps 64-bit SGPR pair
- * alignment; avoids shifting the entire TMP/PARAM/FRAME layout).
+ * enable_sgpr_private_segment_size stays disabled so that workgroup_id_y
+ * lands at s15.  s16 is the last system SGPR, which is where GFX9 and GFX10
+ * are handed the wave's offset into the scratch ring; GFX11 arms FLAT_SCRATCH
+ * itself and never allocates it.  It is reserved on all three anyway, and s17
+ * with it, so that one layout serves every generation and what follows stays
+ * on the even boundary a 64-bit pair needs.
  */
 /*+-------+-------+-------+-------+-------+-------+-----+-----+
  *| s0-s3 | s4-s5 | s6-s7 | s8-s9 |s10-s11|s12-s13| s14 | s15 |
@@ -305,16 +308,16 @@ static_assert(sizeof(struct knod_bpf_subparam_obj) ==
  * The hardware loads these from the dispatch packet before the wave starts,
  * so nothing may be assigned there.  WGY doubles as the queue id.
  *
- *+---------+---------+---------+---------+---------+---------+---------+---------+---------+
- *| s16-s27 | s28-s29 | s30-s31 | s32-s33 | s34-s35 | s36-s47 | s48-s51 | s52-s99 |s100-s101|
- *+---------+---------+---------+---------+---------+---------+---------+---------+---------+
- *| TMP 0-5 |  PARAM  | FP/DESC | unused  |DONE MASK|BLOB XSAV|BLOB TMP |EXEC SAVE|INIT EXEC|
- *+---------+---------+---------+---------+---------+---------+---------+---------+---------+
+ *+---------+---------+---------+---------+---------+---------+---------+---------+---------+---------+
+ *| s16-s17 | s18-s29 | s30-s31 | s32-s33 | s34-s35 | s36-s37 | s38-s49 | s50-s53 | s54-s99 |s100-s101|
+ *+---------+---------+---------+---------+---------+---------+---------+---------+---------+---------+
+ *| SCR OFF | TMP 0-5 |  PARAM  | FP/DESC | unused  |DONE MASK|BLOB XSAV|BLOB TMP |EXEC SAVE|INIT EXEC|
+ *+---------+---------+---------+---------+---------+---------+---------+---------+---------+---------+
  * TMP holds nothing across a BPF instruction.  DONE MASK and INIT EXEC hold
  * theirs across the whole program, and EXEC SAVE across whichever BPF-level
  * scope was given the pair - so a spliced routine gets a window of its own
  * rather than any of those.  FP is written once in the prologue and never
- * read; s[30:31] carries the map descriptor into a routine.
+ * read; s[32:33] carries the map descriptor into a routine.
  */
 #define KNOD_AMDGPU_PSB_SREG		0  /* s[0:3] private_segment_buffer */
 #define KNOD_AMDGPU_DISPATCH_PTR_SREG	4  /* s[4:5] dispatch_ptr */
@@ -325,21 +328,28 @@ static_assert(sizeof(struct knod_bpf_subparam_obj) ==
 #define KNOD_AMDGPU_FLAT_SCR_INIT_SREG	12 /* s[12:13] flat_scratch_init */
 #define KNOD_AMDGPU_WORKGROUP_ID_X_SREG	14 /* s14 workgroup_id_x */
 #define KNOD_AMDGPU_WORKGROUP_ID_Y_SREG	15 /* s15 workgroup_id_y = queue_id */
-#define KNOD_AMDGPU_TMP_SREG0_LO	16
-#define KNOD_AMDGPU_TMP_SREG0_HI	17
-#define KNOD_AMDGPU_TMP_SREG1_LO	18
-#define KNOD_AMDGPU_TMP_SREG1_HI	19
-#define KNOD_AMDGPU_TMP_SREG2_LO	20
-#define KNOD_AMDGPU_TMP_SREG2_HI	21
-#define KNOD_AMDGPU_TMP_SREG3_LO	22
-#define KNOD_AMDGPU_TMP_SREG3_HI	23
-#define KNOD_AMDGPU_TMP_SREG4_LO	24
-#define KNOD_AMDGPU_TMP_SREG4_HI	25
-#define KNOD_AMDGPU_TMP_SREG5_LO	26
-#define KNOD_AMDGPU_TMP_SREG5_HI	27
-#define KNOD_AMDGPU_PARAM_SREG_LO	28 /* s28 */
-#define KNOD_AMDGPU_PARAM_SREG_HI	29 /* s29 */
-#define KNOD_AMDGPU_FRAME_POINTER_SREG	30 /* s30 */
+/* The last system SGPR, where gfx9 and gfx10 are handed the wave's offset
+ * into the scratch ring.  gfx11 arms FLAT_SCRATCH itself and leaves it
+ * unallocated, but the number is reserved on every generation so that one
+ * layout serves all three.  s17 goes with it, to keep what follows on the
+ * even boundary a 64-bit pair needs.
+ */
+#define KNOD_AMDGPU_SCRATCH_WAVE_OFF_SREG 16
+#define KNOD_AMDGPU_TMP_SREG0_LO	18
+#define KNOD_AMDGPU_TMP_SREG0_HI	19
+#define KNOD_AMDGPU_TMP_SREG1_LO	20
+#define KNOD_AMDGPU_TMP_SREG1_HI	21
+#define KNOD_AMDGPU_TMP_SREG2_LO	22
+#define KNOD_AMDGPU_TMP_SREG2_HI	23
+#define KNOD_AMDGPU_TMP_SREG3_LO	24
+#define KNOD_AMDGPU_TMP_SREG3_HI	25
+#define KNOD_AMDGPU_TMP_SREG4_LO	26
+#define KNOD_AMDGPU_TMP_SREG4_HI	27
+#define KNOD_AMDGPU_TMP_SREG5_LO	28
+#define KNOD_AMDGPU_TMP_SREG5_HI	29
+#define KNOD_AMDGPU_PARAM_SREG_LO	30 /* s30 */
+#define KNOD_AMDGPU_PARAM_SREG_HI	31 /* s31 */
+#define KNOD_AMDGPU_FRAME_POINTER_SREG	32 /* s32 */
 
 /* Structurized CFG: EXEC mask save/restore SGPRs.
  * done_mask tracks lanes that have reached BPF_EXIT.
@@ -358,7 +368,7 @@ static_assert(sizeof(struct knod_bpf_subparam_obj) ==
 #define AMDGCN_SREG_INTEGER_1		129
 
 /* s[34:35] - must not overlap TMP_SREGs */
-#define KNOD_AMDGPU_DONE_MASK_SREG	34
+#define KNOD_AMDGPU_DONE_MASK_SREG	36
 /* s36-s51 belongs to whatever routine is spliced in: its own EXEC saves and
  * its scratch scalars.  A BPF-level scope cannot be given one of those,
  * because a splice inside the scope would overwrite it.
@@ -383,8 +393,8 @@ static_assert(sizeof(struct knod_bpf_subparam_obj) ==
  * either.  Everything else the probe needs it works out inside the epilogue,
  * where the scratch scalars are free again.
  */
-#define KNOD_AMDGPU_PROBE_SREG0		32
-#define KNOD_AMDGPU_PROBE_SREG1		33
+#define KNOD_AMDGPU_PROBE_SREG0		34
+#define KNOD_AMDGPU_PROBE_SREG1		35
 
 enum knod_probe_stage {
 	KNOD_PROBE_PRO_START,

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -3394,6 +3394,7 @@ static int knod_bpf_check_percpu_store(struct knod_prog *knod_prog,
 				       struct knod_insn_meta *meta)
 {
 	struct knod_insn_meta *alu, *load;
+	const char *why;
 
 	alu = knod_bpf_lookup_prev_meta_by_dreg(knod_prog, meta,
 						meta->insn.src_reg);
@@ -3415,18 +3416,28 @@ static int knod_bpf_check_percpu_store(struct knod_prog *knod_prog,
 		meta->percpu_rmw_swapped = true;
 	}
 
-	if (BPF_OP(alu->insn.code) != BPF_ADD)
+	if (BPF_OP(alu->insn.code) != BPF_ADD) {
+		why = "only an add has an atomic form here; write it with __sync_fetch_and_add()";
 		goto reject;
+	}
 
 	/* There is no atomic narrower than a dword, and a 64-bit one hangs
 	 * GFX9 against VRAM.
 	 */
 	if (BPF_SIZE(meta->insn.code) != BPF_W &&
-	    BPF_SIZE(meta->insn.code) != BPF_DW)
+	    BPF_SIZE(meta->insn.code) != BPF_DW) {
+		why = "no atomic is narrower than a dword; widen the value to __u32";
 		goto reject;
+	}
 	if (BPF_SIZE(meta->insn.code) == BPF_DW &&
-	    knod_prog->knod->isa_version == 9)
+	    knod_prog->knod->isa_version == 9) {
+		/* Saying "use an atomic" here would send them at a wall: the
+		 * explicit form is refused too, this part has no 64-bit atomic
+		 * at all.
+		 */
+		why = "this GPU has no 64-bit atomic, so no form of a 64-bit counter offloads; make it __u32";
 		goto reject;
+	}
 
 	meta->percpu_rmw_add = alu;
 	meta->percpu_rmw_uniform =
@@ -3434,8 +3445,8 @@ static int knod_bpf_check_percpu_store(struct knod_prog *knod_prog,
 	return 0;
 
 reject:
-	pr_warn("knod_bpf: percpu value at +%d is read and written back (bpf insn %d) in a way that cannot be offloaded as one atomic, and %u lanes would do it at once and lose all but one; write it with __sync_fetch_and_add()\n",
-		meta->insn.off, meta->bpf_insn_idx, knod_bpf_workgroups);
+	pr_warn("knod_bpf: percpu value at +%d is read and written back (bpf insn %d) where %u lanes would do it at once and lose all but one: %s\n",
+		meta->insn.off, meta->bpf_insn_idx, knod_bpf_workgroups, why);
 	return -EOPNOTSUPP;
 }
 

--- a/include/uapi/linux/knod_blob.h
+++ b/include/uapi/linux/knod_blob.h
@@ -19,7 +19,7 @@
 #include <linux/types.h>
 
 #define KNOD_BLOB_MAGIC		0x4b4e4442	/* 'KNDB' */
-#define KNOD_BLOB_ABI_VERSION	9
+#define KNOD_BLOB_ABI_VERSION	10
 
 /*
  * How a routine is reached.  SPLICE is what the JIT does: the bytes are copied
@@ -123,7 +123,7 @@ enum knod_blob_kind {
  * so it arrives in an SGPR pair, and every other address a routine needs is a
  * scalar load away from it.  Nothing in a blob has to be relocated.
  */
-#define KNOD_BLOB_SPLICE_DESC_SREG	30	/* s[30:31] map descriptor */
+#define KNOD_BLOB_SPLICE_DESC_SREG	32	/* s[32:33] map descriptor */
 /* The window stops below what the prologue leaves for the epilogue, the first
  * of which is the lane's slot at v[58:59].
  */
@@ -166,13 +166,13 @@ enum knod_blob_kind {
 /*
  * Register binding, call linkage.  Matches the AMDGPU function ABI so that a
  * routine can be compiled: arguments in the low registers, return address in
- * s[30:31].
+ * s[32:33].
  */
 #define KNOD_BLOB_CALL_DESC_SREG	0	/* s[0:1] */
 #define KNOD_BLOB_CALL_KEY_VREG		0	/* v[0:1] */
 #define KNOD_BLOB_CALL_VAL_VREG		2	/* v[2:3] */
 #define KNOD_BLOB_CALL_RET_VREG		0	/* v[0:1] */
-#define KNOD_BLOB_CALL_RET_ADDR_SREG	30	/* s[30:31] */
+#define KNOD_BLOB_CALL_RET_ADDR_SREG	32	/* s[32:33] */
 
 /*
  * Where a routine saves EXEC, and the scalars it may destroy while running.
@@ -181,25 +181,25 @@ enum knod_blob_kind {
  * JIT keeps the whole range free instead, and an entry says through
  * exec_save_pairs how much of the first part a routine uses.
  *
- * Nothing below this is scratch.  In particular s[34:35] carries the mask of
+ * Nothing below this is scratch.  In particular s[36:37] carries the mask of
  * lanes that have reached a verdict, which is live from wherever a lane
  * finished to the epilogue that reads it, and so across any splice.
  */
-#define KNOD_BLOB_EXEC_SAVE_SREG	36	/* s[36:37] .. s[46:47] */
+#define KNOD_BLOB_EXEC_SAVE_SREG	38	/* s[38:39] .. s[48:49] */
 #define KNOD_BLOB_EXEC_SAVE_PAIRS_MAX	6
-#define KNOD_BLOB_SPLICE_TMP_SREG	48	/* s48-s51 clobberable */
-#define KNOD_BLOB_SPLICE_TMP_SREG_END	51
+#define KNOD_BLOB_SPLICE_TMP_SREG	50	/* s50-s53 clobberable */
+#define KNOD_BLOB_SPLICE_TMP_SREG_END	53
 
 /*
  * The JIT's own scalars, at the same numbers on every generation so that a
  * routine names them without asking which GPU it was built for.
  */
-#define KNOD_BLOB_DONE_MASK_SREG	34
+#define KNOD_BLOB_DONE_MASK_SREG	36
 /* What a probe build holds across the program: what the prologue took, and
- * when it ended.  s[32:33] is the pair nothing else claims - GFX9 corrupts it,
+ * when it ended.  s[34:35] is the pair nothing else claims - GFX9 corrupts it,
  * which costs nothing because GFX9 has no cycle counter to read either.
  */
-#define KNOD_BLOB_PROBE_SREG		32
+#define KNOD_BLOB_PROBE_SREG		34
 
 #define KNOD_BLOB_INITIAL_EXEC_SREG	100
 
@@ -374,8 +374,8 @@ struct knod_blob_map_desc {
 #define KNOD_BLOB_PRO_DISPATCH_SREG	4	/* s[4:5] dispatch packet */
 #define KNOD_BLOB_PRO_WG_X_SREG		14
 #define KNOD_BLOB_PRO_WG_Y_SREG		15	/* also the queue id */
-#define KNOD_BLOB_PRO_PARAM_SREG	28	/* s[28:29] parameter block */
-#define KNOD_BLOB_PRO_FRAME_SREG	30
+#define KNOD_BLOB_PRO_PARAM_SREG	30	/* s[30:31] parameter block */
+#define KNOD_BLOB_PRO_FRAME_SREG	32
 #define KNOD_BLOB_PRO_TID_VREG		0	/* v0, from the hardware */
 
 /* What the prologue leaves behind. */
@@ -398,7 +398,7 @@ struct knod_blob_map_desc {
  * gets, plus the scalars nothing holds across a dispatch.
  */
 #define KNOD_BLOB_PRO_TMP_VREG		22	/* v22-v57 */
-#define KNOD_BLOB_PRO_TMP_SREG		16	/* s16-s27 */
+#define KNOD_BLOB_PRO_TMP_SREG		18	/* s18-s29 */
 
 #ifndef __ASSEMBLY__
 


### PR DESCRIPTION
Pairs with TaeheeYoo/knod-blob#21 — both trees move together, the blob ABI goes
from 9 to 10.

## Why a scalar has to move

gfx11 arms FLAT_SCRATCH itself, which is why #41 could put the BPF stack in
scratch there without touching a single scalar. gfx9 and gfx10 do not. Both are
handed the wave's offset into the scratch ring in the last system SGPR, and
without it every wave shares slot zero and they trample each other. With
`workgroup_id_y` at s15 and nothing else enabled, that register is s16 — and
s16 is where `TMP_SREG0` started.

Measured rather than assumed, with `amdclang` on a spilling kernel
(`-mwavefrontsize64 -Xclang -target-feature -Xclang +enable-flat-scratch`):

| | gfx9 | gfx10 | gfx11 |
|---|---|---|---|
| prologue | `s_add_u32 flat_scratch_lo, init, wave_off` | same, then `s_setreg hwreg(HW_REG_FLAT_SCR_LO/HI)` | **none** |
| instruction | `off, v[..], SADDR` | `off, v[..], off` | `off, v[..], off` |
| `user_sgpr_flat_scratch_init` | 1 | 1 | 0 |
| `system_sgpr_private_segment_wavefront_offset` | **1** | **1** | **0** |

## The shift

Up by two, not one: s17 is not a legal base for a 64-bit pair and everything
above TMP is pairs, so s17 is padding rather than a register anyone gains.
Nothing moves for a reason of its own — it is one shift of the block.

| | before | after |
|---|---|---|
| TMP 0-5 | s16-s27 | s18-s29 |
| PARAM | s28-s29 | s30-s31 |
| FP, DESC | s30-s31 | s32-s33 |
| DONE MASK | s34-s35 | s36-s37 |
| BLOB XSAVE | s36-s47 | s38-s49 |
| BLOB TMP | s48-s51 | s50-s53 |

The reservation is made on **every** generation, gfx11 included, even though
gfx11 never allocates the register. One layout for all three is the point, and
what it costs is two scalars idle on one generation out of a hundred. The
alternative — a per-generation blob ABI — trades that for splitting every
routine three ways.

Nothing else changes yet. gfx9 and gfx10 still keep the stack in registers; what
they additionally need is a prologue building FLAT_SCRATCH out of
FLAT_SCRATCH_INIT and this offset, and scratch emitters of their own, gfx9's
taking an SADDR where the other two take none. Doing the renumbering first means
that lands without moving the blob ABI a second time.

**This commit is a pure renumbering** — no descriptor bit is set, so all three
generations behave exactly as before and s16/s17 simply go unused. Verified on
gfx1030 with the blob engine: 40.66 Mpps, no expired dispatches, and the
regenerated BPF assembly mentions neither s16 nor s17.

IPsec is untouched. It uses none of these symbols and the `s16` in its own
assembly is its own convention under its own descriptor.

## The second commit

A percpu value read and written back non-atomically loses all but one lane, and
the refusal told you to use `__sync_fetch_and_add()`. Right for two of the three
ways to arrive there, wrong for the third: a 64-bit counter on GFX9 is refused
again by the explicit form, because that part has no 64-bit atomic at all. So
the advice sent you at a wall and the second message would have been a different
one. Found while trying to run kondor on gfx9.

Each of the three now says which wall it is, and for the GFX9 case names the
real fix — a narrower counter, not a different way of writing the same one.

Worth noting separately: that GFX9 refusal dates from the original JIT commit in
July, and reads `global_atomic_*_x2` hangs against VRAM. Two things that would
cause exactly that have been fixed since and neither was known then — the atomic
target was 4-byte aligned until August, and maps were `MTYPE_UC` until two days
ago. Vega's ISA has the instruction. The guard is probably stale, but nobody has
run a 64-bit percpu counter on gfx9 to find out, so it stays for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)