### PR TITLE
drm/amdkfd: knod: put the BPF stack in scratch on gfx10 too

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_amdgpu_insn.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_amdgpu_insn.h
@@ -1496,6 +1496,10 @@ static inline void emit_scratch_load_dword(int version,
 		insn->size = emit_gfx11_scratch_load_dword(&insn->gfx11, dst,
 							   off);
 		insn->type = AMDGCN_INSN_TYPE_FLAT;
+	} else if (version == 10) {
+		insn->size = emit_gfx10_scratch_load_dword(&insn->gfx10, dst,
+							   off);
+		insn->type = AMDGCN_INSN_TYPE_FLAT;
 	} else {
 		WARN_ON_ONCE(1);
 	}
@@ -1510,6 +1514,52 @@ static inline void emit_scratch_store_dword(int version,
 		insn->size = emit_gfx11_scratch_store_dword(&insn->gfx11, src,
 							    off);
 		insn->type = AMDGCN_INSN_TYPE_FLAT;
+	} else if (version == 10) {
+		insn->size = emit_gfx10_scratch_store_dword(&insn->gfx10, src,
+							    off);
+		insn->type = AMDGCN_INSN_TYPE_FLAT;
+	} else {
+		WARN_ON_ONCE(1);
+	}
+}
+
+/* Arming FLAT_SCRATCH is gfx10's alone: gfx11 is handed it, and gfx9 writes
+ * the scalar pair directly because there it is addressable as s[102:103].
+ */
+static inline void emit_s_setreg_b32(int version, struct amdgcn_insn *insn,
+				     int ssrc, u16 hwreg)
+{
+	if (version == 10) {
+		insn->size = emit_gfx10_s_setreg_b32(&insn->gfx10, ssrc, hwreg);
+		insn->type = AMDGCN_INSN_TYPE_SOPK;
+	} else {
+		WARN_ON_ONCE(1);
+	}
+}
+
+static inline void emit_s_add_u32(int version, struct amdgcn_insn *insn,
+				  struct amdgcn_param32 dst,
+				  struct amdgcn_param32 src0,
+				  struct amdgcn_param32 src1)
+{
+	if (version == 10) {
+		insn->size = emit_gfx10_s_add_u32(&insn->gfx10, dst, src0,
+						 src1);
+		insn->type = AMDGCN_INSN_TYPE_SOP2;
+	} else {
+		WARN_ON_ONCE(1);
+	}
+}
+
+static inline void emit_s_addc_u32(int version, struct amdgcn_insn *insn,
+				  struct amdgcn_param32 dst,
+				  struct amdgcn_param32 src0,
+				  struct amdgcn_param32 src1)
+{
+	if (version == 10) {
+		insn->size = emit_gfx10_s_addc_u32(&insn->gfx10, dst, src0,
+						 src1);
+		insn->type = AMDGCN_INSN_TYPE_SOP2;
 	} else {
 		WARN_ON_ONCE(1);
 	}
@@ -1919,6 +1969,13 @@ static inline void emit_s_cbranch_execnz(int version, struct amdgcn_insn *insn,
  * that has one.  GFX9 has no equivalent, so a caller there gets nothing.
  */
 #define KNOD_HWREG_SHADER_CYCLES_20	0x981d
+
+/* The two halves of FLAT_SCRATCH, which is how gfx10 is written: gfx11 needs
+ * no writing and gfx9 addresses the pair as s[102:103] instead.
+ */
+#define KNOD_HWREG_FLAT_SCR_LO_32	0xf814
+#define KNOD_HWREG_FLAT_SCR_HI_32	0xf815
+
 
 static inline void emit_s_getreg_b32(int version, struct amdgcn_insn *insn,
 				     u8 sdst, u16 hwreg)

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -470,17 +470,46 @@ static bool knod_stack_in_scratch(int isa_version)
 	if (knod_bpf_stack_cache)
 		return false;
 
-	if (isa_version != 11) {
-		pr_warn_once("knod_bpf: stack_cache=0 needs gfx11; keeping the stack in registers\n");
+	if (isa_version != 10 && isa_version != 11) {
+		pr_warn_once("knod_bpf: stack_cache=0 needs gfx10 or gfx11; keeping the stack in registers\n");
 		return false;
 	}
 
 	return true;
 }
 
+
 static bool knod_bpf_stack_in_scratch(struct knod_bpf_priv *priv)
 {
 	return knod_stack_in_scratch(priv->isa_version);
+}
+
+/* gfx10 is handed the ring's base in FLAT_SCRATCH_INIT and its own slot in
+ * the wave offset, and has to add them together itself; gfx11 arrives with
+ * FLAT_SCRATCH already armed and wants none of this.
+ */
+static void knod_bpf_emit_flat_scratch_init(struct knod_bpf_priv *priv,
+					    struct knod_insn_meta *meta)
+{
+	struct amdgcn_param32 p32[3];
+
+	if (!knod_bpf_stack_in_scratch(priv) || priv->isa_version != 10)
+		return;
+
+	knod_sset32(&p32[0], KNOD_AMDGPU_TMP_SREG0_LO);
+	knod_sset32(&p32[1], KNOD_AMDGPU_FLAT_SCR_INIT_SREG);
+	knod_sset32(&p32[2], KNOD_AMDGPU_SCRATCH_WAVE_OFF_SREG);
+	knod_emit(priv, meta, s_add_u32, p32[0], p32[1], p32[2]);
+
+	knod_sset32(&p32[0], KNOD_AMDGPU_TMP_SREG0_HI);
+	knod_sset32(&p32[1], KNOD_AMDGPU_FLAT_SCR_INIT_SREG + 1);
+	knod_iset32(&p32[2], 0);
+	knod_emit(priv, meta, s_addc_u32, p32[0], p32[1], p32[2]);
+
+	knod_emit(priv, meta, s_setreg_b32, KNOD_AMDGPU_TMP_SREG0_LO,
+		  KNOD_HWREG_FLAT_SCR_LO_32);
+	knod_emit(priv, meta, s_setreg_b32, KNOD_AMDGPU_TMP_SREG0_HI,
+		  KNOD_HWREG_FLAT_SCR_HI_32);
 }
 
 /* Whether a workgroup takes the whole WGP.  In CU mode its waves sit on one CU
@@ -4337,6 +4366,11 @@ static int knod_prog_prepare_insns(struct knod_bpf_priv *priv,
 		meta->blob = knod_blob_find(&priv->blob, KNOD_BLOB_PROLOGUE, 0,
 						&meta->blob_size);
 		if (meta->blob) {
+			/* blob_at is zero, so what this emits lands after the
+			 * routine - which is where it belongs, the prologue
+			 * reaching no scratch of its own.
+			 */
+			knod_bpf_emit_flat_scratch_init(priv, meta);
 			list_add_tail(&meta->l, &knod_prog->pre_insns);
 			return 0;
 		}
@@ -4352,6 +4386,8 @@ static int knod_prog_prepare_insns(struct knod_bpf_priv *priv,
 	 */
 	knod_emit(priv, meta, s_icache_inv);
 	knod_emit(priv, meta, s_waitcnt_vmcnt_lgkmcnt);
+
+	knod_bpf_emit_flat_scratch_init(priv, meta);
 
 	knod_bpf_emit_cycle_probe(priv, meta, KNOD_PROBE_PRO_START);
 

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_gfx10_insn.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_gfx10_insn.h
@@ -1622,6 +1622,11 @@ struct amdgcn_gfx10_mimg {
  * offset per lane.
  */
 #define GFX10_FLAT_SADDR_DISABLE                 GFX10_FLAT_SADDR_NULL
+/* Scratch spells "no SADDR" as all ones rather than as the scalar operand
+ * namespace's NULL, which is what GLOBAL above uses.  Reusing that one here
+ * encodes s125 and the address comes out somewhere else entirely.
+ */
+#define GFX10_FLAT_SADDR_SCRATCH_OFF             127
 #define GFX10_FLAT_SEG_FLAT                      0
 #define GFX10_FLAT_SEG_SCRATCH                   1
 #define GFX10_FLAT_SEG_GLOBAL                    2
@@ -3530,6 +3535,11 @@ inline u32 emit_gfx10_s_cbranch_execnz(union amdgcn_gfx10_insn *insn,
 #define GFX10_HWREG(id, off, sz)	(((sz) - 1) << 11 | (off) << 6 | (id))
 /* A free-running count of shader clocks, twenty bits wide. */
 #define GFX10_HW_REG_SHADER_CYCLES	29
+/* FLAT_SCRATCH is not addressable as a scalar here the way it is on GFX9;
+ * a wave arms it by writing these two.
+ */
+#define GFX10_HW_REG_FLAT_SCR_LO	20
+#define GFX10_HW_REG_FLAT_SCR_HI	21
 
 inline u32 emit_gfx10_s_getreg_b32(union amdgcn_gfx10_insn *insn,
 				   int sdst, u16 hwreg)
@@ -3537,6 +3547,17 @@ inline u32 emit_gfx10_s_getreg_b32(union amdgcn_gfx10_insn *insn,
 	insn->sopk.encoding = GFX10_SOPK_ENCODING;
 	insn->sopk.op = GFX10_S_GETREG_B32;
 	insn->sopk.sdst = sdst;
+	insn->sopk.simm16 = hwreg;
+	return 4;
+}
+
+/* s_setreg_b32 hwreg, ssrc - the write half of s_getreg_b32 above. */
+inline u32 emit_gfx10_s_setreg_b32(union amdgcn_gfx10_insn *insn,
+				   int ssrc, u16 hwreg)
+{
+	insn->sopk.encoding = GFX10_SOPK_ENCODING;
+	insn->sopk.op = GFX10_S_SETREG_B32;
+	insn->sopk.sdst = ssrc;
 	insn->sopk.simm16 = hwreg;
 	return 4;
 }
@@ -3931,6 +3952,56 @@ inline u32 emit_gfx10_ds_read_b128(union amdgcn_gfx10_insn *insn,
 				    int vdst, int addr)
 {
 	__emit_gfx10_ds(insn, GFX10_DS_READ_B128, addr, 0, vdst, 0, 0);
+	return 8;
+}
+
+/* --- SCRATCH ---
+ * Neither VADDR nor SADDR, so the address is the wave's own scratch base plus
+ * the immediate.  The hardware interleaves lanes within that, which is what
+ * makes a wave reading one stack slot a contiguous read of memory rather than
+ * one cache line per lane.
+ */
+static inline u32 emit_gfx10_scratch_load_dword(union amdgcn_gfx10_insn *insn,
+						struct amdgcn_param32 dst,
+						short off)
+{
+	insn->flat.offset = off;
+	insn->flat.dlc = 0;
+	insn->flat.lds = 0;
+	insn->flat.seg = GFX10_FLAT_SEG_SCRATCH;
+	insn->flat.glc = 0;
+	insn->flat.slc = 0;
+	insn->flat.op = GFX10_SCRATCH_LOAD_DWORD;
+	insn->flat.encoding = GFX10_FLAT_ENCODING;
+	insn->flat.addr = 0;
+	insn->flat.data = 0;
+	insn->flat.saddr = GFX10_FLAT_SADDR_SCRATCH_OFF;
+	insn->flat.dummy1 = 0;
+	insn->flat.dummy2 = 0;
+	insn->flat.vdst = dst.v;
+
+	return 8;
+}
+
+static inline u32 emit_gfx10_scratch_store_dword(union amdgcn_gfx10_insn *insn,
+						 struct amdgcn_param32 src,
+						 short off)
+{
+	insn->flat.offset = off;
+	insn->flat.dlc = 0;
+	insn->flat.lds = 0;
+	insn->flat.seg = GFX10_FLAT_SEG_SCRATCH;
+	insn->flat.glc = 0;
+	insn->flat.slc = 0;
+	insn->flat.op = GFX10_SCRATCH_STORE_DWORD;
+	insn->flat.encoding = GFX10_FLAT_ENCODING;
+	insn->flat.addr = 0;
+	insn->flat.data = src.v;
+	insn->flat.saddr = GFX10_FLAT_SADDR_SCRATCH_OFF;
+	insn->flat.dummy1 = 0;
+	insn->flat.dummy2 = 0;
+	insn->flat.vdst = 0;
+
 	return 8;
 }
 


### PR DESCRIPTION
Follows #42, which reserved the scalars. This arms them. No blob half — the
routines carry no numbers of their own and the ABI is unchanged from 10.

gfx11 arrives with FLAT_SCRATCH already set up. gfx10 is handed the ring's base
in `FLAT_SCRATCH_INIT` and its own slot in the wave offset, and has to add them
together itself:

```
s_add_u32    s18, s12, s16
s_addc_u32   s19, s13, 0
s_setreg_b32 hwreg(HW_REG_FLAT_SCR_LO), s18
s_setreg_b32 hwreg(HW_REG_FLAT_SCR_HI), s19
```

Those go **after** the prologue rather than before it, on both engines, because
`s_icache_inv` has to stay the first instruction at the entry point and the
prologue reaches no scratch of its own. A meta carries a spliced routine and
emitted instructions at once, so the blob path needs nothing special.

## The encoding trap

"No SADDR" is spelled differently by segment and by generation, and the value
already in the tree is the wrong one here:

| | |
|---|---|
| gfx10 GLOBAL | 125 (`SADDR_NULL`) |
| **gfx10 SCRATCH** | **127** |
| gfx11 SCRATCH | 124 |

Reusing `GFX10_FLAT_SADDR_DISABLE` would have encoded s125 and put the address
somewhere else entirely, quietly. Every instruction added here was assembled with
`llvm-mc` and compared byte for byte before being trusted — six of them, all
matching.

## Measured

gfx1030, blob engine, 22 queues of 128:

| | throughput | ns/lane |
|---|---|---|
| stack in VGPRs | 40.66 Mpps | 24.54 |
| stack in scratch | **40.03 Mpps** | 24.91 |

A percent and a half, with 44 wave64s against 160 SIMDs — which is to say with
nothing to hide the added latency behind. What that mostly measures is how little
of the stack kondor touches. `expired` stayed at zero; the tail thickened a
little, 338 dispatches over 256 µs becoming 2229.

## One thing found on the way

`emit_gfx10_s_add_u32` and `emit_gfx10_s_addc_u32` already existed, generated by
`DEFINE_GFX10_SOP2_P`, so grepping for them found nothing and the first draft
added duplicates. The macro versions are better than what I had written: they
take `param32` and pick the inline-constant form or the literal form on their
own. `s_setreg_b32` genuinely was missing and is new.

## Still to come

gfx9. It needs no `s_setreg` — FLAT_SCRATCH is addressable there as s[102:103],
which knod's map already keeps clear — so its prologue is two instructions rather
than four. Its scratch instructions take an SADDR where gfx10 and gfx11 take
none, and its own spelling of "no SADDR" wants checking against `llvm-mc` before
anything is written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)