### PR TITLE
drm/amdkfd: knod: let the BPF stack live in LDS

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/kfd_knod.c
+++ b/drivers/gpu/drm/amd/amdkfd/kfd_knod.c
@@ -1436,6 +1436,9 @@ struct knod *knod_alloc_ctx(struct knod_dev *knodev, int queue_cnt, int id,
 				 topo_dev->node_props.simd_per_cu;
 	if (!knod->cu_count)
 		knod->cu_count = 1;
+	knod->lds_size = topo_dev->node_props.lds_size_in_kb * 1024;
+	if (!knod->lds_size)
+		knod->lds_size = 65536;
 	pr_info("knod: AQL queues=%d SDMA queues=%d channels=%d CUs=%d\n",
 		queue_cnt, knod->sdma_cnt, channels, knod->cu_count);
 

--- a/drivers/gpu/drm/amd/amdkfd/knod/kfd_knod.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/kfd_knod.h
@@ -178,6 +178,8 @@ struct knod {
 	int queue_cnt;
 	int sdma_cnt;
 	int cu_count;
+	/* LDS a workgroup can have, in bytes, as the topology reports it. */
+	u32 lds_size;
 	int igpu;
 	int isa_version;
 	/* maj * 10000 + min * 100 + step, which is how LLVM spells a target:

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_amdgpu_insn.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_amdgpu_insn.h
@@ -1526,6 +1526,51 @@ static inline void emit_scratch_store_dword(int version,
 /* Arming FLAT_SCRATCH is gfx10's alone: gfx11 is handed it, and gfx9 writes
  * the scalar pair directly because there it is addressable as s[102:103].
  */
+/* LDS, with the whole sixteen-bit offset: DS_*_B32 reads offset1:offset0 as
+ * one number, and the per-generation _off helpers fill only the low byte.
+ */
+static inline void emit_ds_read_b32(int version, struct amdgcn_insn *insn,
+				    struct amdgcn_param32 dst,
+				    struct amdgcn_param32 addr, u16 off)
+{
+	WARN_ON(dst.type != AMDGCN_PARAM_TYPE_VGPR ||
+		addr.type != AMDGCN_PARAM_TYPE_VGPR);
+	if (version == 11) {
+		__emit_gfx11_ds(&insn->gfx11, GFX11_DS_LOAD_B32, addr.v, 0,
+				dst.v, off & 0xff, off >> 8);
+		insn->size = 8;
+		insn->type = AMDGCN_INSN_TYPE_DS;
+	} else if (version == 10) {
+		__emit_gfx10_ds(&insn->gfx10, GFX10_DS_READ_B32, addr.v, 0,
+				dst.v, off & 0xff, off >> 8);
+		insn->size = 8;
+		insn->type = AMDGCN_INSN_TYPE_DS;
+	} else {
+		WARN_ON_ONCE(1);
+	}
+}
+
+static inline void emit_ds_write_b32(int version, struct amdgcn_insn *insn,
+				     struct amdgcn_param32 addr,
+				     struct amdgcn_param32 src, u16 off)
+{
+	WARN_ON(src.type != AMDGCN_PARAM_TYPE_VGPR ||
+		addr.type != AMDGCN_PARAM_TYPE_VGPR);
+	if (version == 11) {
+		__emit_gfx11_ds(&insn->gfx11, GFX11_DS_STORE_B32, addr.v, src.v,
+				0, off & 0xff, off >> 8);
+		insn->size = 8;
+		insn->type = AMDGCN_INSN_TYPE_DS;
+	} else if (version == 10) {
+		__emit_gfx10_ds(&insn->gfx10, GFX10_DS_WRITE_B32, addr.v, src.v,
+				0, off & 0xff, off >> 8);
+		insn->size = 8;
+		insn->type = AMDGCN_INSN_TYPE_DS;
+	} else {
+		WARN_ON_ONCE(1);
+	}
+}
+
 static inline void emit_s_setreg_b32(int version, struct amdgcn_insn *insn,
 				     int ssrc, u16 hwreg)
 {

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -198,6 +198,8 @@ static_assert(sizeof(struct knod_bpf_subparam_obj) ==
  */
 #define KNOD_AMDGPU_STACK_WIN_VREG0	128
 #define KNOD_AMDGPU_STACK_WIN_VREG1	129
+/* The lane's byte offset into the LDS stack, lane * 4, computed once. */
+#define KNOD_AMDGPU_LDS_BASE_VREG	130
 
 /* One VGPR holds four bytes of packet, so what the cache can hold is decided
  * by how many VGPRs sit between its base and the stack.
@@ -462,27 +464,61 @@ module_param_named(jit_engine, knod_bpf_jit_engine, int, 0600);
  * below gfx11 has scratch brought up, though.
  */
 unsigned int knod_bpf_stack_cache = 1;
-MODULE_PARM_DESC(stack_cache, "BPF stack in 1=VGPRs(Default), 0=scratch");
+MODULE_PARM_DESC(stack_cache, "BPF stack in 1=VGPRs(Default), 0=scratch, 2=LDS");
+
+enum knod_stack_mode {
+	KNOD_STACK_SCRATCH = 0,
+	KNOD_STACK_VGPR = 1,
+	KNOD_STACK_LDS = 2,
+};
 module_param_named(stack_cache, knod_bpf_stack_cache, int, 0600);
+
+static enum knod_stack_mode knod_stack_mode(int isa_version)
+{
+	switch (knod_bpf_stack_cache) {
+	case KNOD_STACK_SCRATCH:
+	case KNOD_STACK_LDS:
+		if (isa_version == 10 || isa_version == 11)
+			return knod_bpf_stack_cache;
+		pr_warn_once("knod_bpf: stack_cache=%u needs gfx10 or gfx11; keeping the stack in registers\n",
+			     knod_bpf_stack_cache);
+		return KNOD_STACK_VGPR;
+	default:
+		return KNOD_STACK_VGPR;
+	}
+}
 
 static bool knod_stack_in_scratch(int isa_version)
 {
-	if (knod_bpf_stack_cache)
-		return false;
-
-	if (isa_version != 10 && isa_version != 11) {
-		pr_warn_once("knod_bpf: stack_cache=0 needs gfx10 or gfx11; keeping the stack in registers\n");
-		return false;
-	}
-
-	return true;
+	return knod_stack_mode(isa_version) == KNOD_STACK_SCRATCH;
 }
-
 
 static bool knod_bpf_stack_in_scratch(struct knod_bpf_priv *priv)
 {
 	return knod_stack_in_scratch(priv->isa_version);
 }
+
+static bool knod_bpf_stack_in_lds(struct knod_bpf_priv *priv)
+{
+	return knod_stack_mode(priv->isa_version) == KNOD_STACK_LDS;
+}
+
+/* Anything but registers goes through the two-register window. */
+static bool knod_bpf_stack_in_mem(struct knod_bpf_priv *priv)
+{
+	return knod_stack_mode(priv->isa_version) != KNOD_STACK_VGPR;
+}
+
+static void knod_lshlrev32(struct knod_bpf_priv *priv,
+			   struct knod_insn_meta *meta,
+			   struct amdgcn_param32 dst,
+			   struct amdgcn_param32 src0,
+			   struct amdgcn_param32 src1);
+static void knod_and32(struct knod_bpf_priv *priv,
+		      struct knod_insn_meta *meta,
+		      struct amdgcn_param32 dst,
+		      struct amdgcn_param32 src0,
+		      struct amdgcn_param32 src1);
 
 /* gfx10 is handed the ring's base in FLAT_SCRATCH_INIT and its own slot in
  * the wave offset, and has to add them together itself; gfx11 arrives with
@@ -492,6 +528,18 @@ static void knod_bpf_emit_flat_scratch_init(struct knod_bpf_priv *priv,
 					    struct knod_insn_meta *meta)
 {
 	struct amdgcn_param32 p32[3];
+
+	if (knod_bpf_stack_in_lds(priv)) {
+		struct amdgcn_param32 base, idx, k;
+
+		knod_vset32(&base, KNOD_AMDGPU_LDS_BASE_VREG);
+		knod_vset32(&idx, KNOD_AMDGPU_IDX_VREG);
+		knod_iset32(&k, knod_bpf_workgroups - 1);
+		knod_and32(priv, meta, base, k, idx);
+		knod_iset32(&k, 2);
+		knod_lshlrev32(priv, meta, base, k, base);
+		return;
+	}
 
 	if (!knod_bpf_stack_in_scratch(priv) || priv->isa_version != 10)
 		return;
@@ -600,14 +648,14 @@ static void knod_bpf_fill_dispatch(struct knod_bpf_priv *priv,
 				   struct knod_dispatch_params *p)
 {
 	struct knod_bpf_param *param = sqw->param->kaddr;
+	int idx = READ_ONCE(priv->active_idx);
 
 	p->workgroup_size_x = knod_bpf_workgroups;
 	p->grid_size_x = priv->batch_size;
 	p->grid_size_y = param->nr_queues;
 	p->private_segment_size = KNOD_SCRATCH_BYTES_PER_LANE;
-	p->group_segment_size = KNOD_BPF_LDS_SIZE;
-	p->kernel_object =
-		(u64)priv->knod->kernels[READ_ONCE(priv->active_idx)]->gaddr;
+	p->group_segment_size = priv->lds_bytes[idx];
+	p->kernel_object = (u64)priv->knod->kernels[idx]->gaddr;
 	p->kernarg_address = sqw->param->gaddr;
 }
 
@@ -1315,6 +1363,7 @@ static void knod_bpf_install_kernel(struct knod_bpf_priv *priv,
 	 */
 	wmb();
 	knod_bpf_gpu_mem_fence(priv);
+	priv->lds_bytes[idx] = knod_prog->lds_bytes;
 	WRITE_ONCE(priv->kernel_image_len[idx], image_len);
 
 	if (idx != priv->active_idx)
@@ -1508,6 +1557,7 @@ static int knod_bpf_jit_pass_kernel(struct knod_bpf_priv *priv)
 	INIT_LIST_HEAD(&pass_prog.insns);
 	INIT_LIST_HEAD(&pass_prog.post_insns);
 	pass_prog.knod = knod;
+	pass_prog.lds_bytes = 0;
 	pass_prog.knodev = priv->knodev;
 	pass_prog.done_mask_sreg = KNOD_AMDGPU_DONE_MASK_SREG;
 	pass_prog.exec_save_base = KNOD_AMDGPU_EXEC_SAVE_SREG_BASE;
@@ -4058,6 +4108,19 @@ static int knod_bpf_verify_insn(struct bpf_verifier_env *env,
 		knod_prog->max_stack_off = meta->sreg.stack_off;
 	if (knod_prog->max_stack_off > meta->dreg.stack_off)
 		knod_prog->max_stack_off = meta->dreg.stack_off;
+	/* A load or store reaches insn.off past its register, so the register
+	 * alone understates the depth by exactly that - which is why this was
+	 * computed for years and read by nothing: it was never quite right.
+	 */
+	if (BPF_CLASS(meta->insn.code) == BPF_LDX &&
+	    meta->ptr.type == PTR_TO_STACK &&
+	    knod_prog->max_stack_off > meta->sreg.stack_off + meta->insn.off)
+		knod_prog->max_stack_off = meta->sreg.stack_off + meta->insn.off;
+	if ((BPF_CLASS(meta->insn.code) == BPF_STX ||
+	     BPF_CLASS(meta->insn.code) == BPF_ST) &&
+	    meta->ptr.type == PTR_TO_STACK &&
+	    knod_prog->max_stack_off > meta->dreg.stack_off + meta->insn.off)
+		knod_prog->max_stack_off = meta->dreg.stack_off + meta->insn.off;
 	if (knod_prog->max_packet_off < meta->sreg.packet_off)
 		knod_prog->max_packet_off = meta->sreg.packet_off;
 	if (knod_prog->max_packet_off < meta->dreg.packet_off)
@@ -4387,8 +4450,6 @@ static int knod_prog_prepare_insns(struct knod_bpf_priv *priv,
 	knod_emit(priv, meta, s_icache_inv);
 	knod_emit(priv, meta, s_waitcnt_vmcnt_lgkmcnt);
 
-	knod_bpf_emit_flat_scratch_init(priv, meta);
-
 	knod_bpf_emit_cycle_probe(priv, meta, KNOD_PROBE_PRO_START);
 
 	knod_sset32(&param[0], KNOD_AMDGPU_PARAM_SREG_LO);
@@ -4411,6 +4472,8 @@ static int knod_prog_prepare_insns(struct knod_bpf_priv *priv,
 	 */
 	knod_emit(priv, meta, v_bfe_i32, param[0], param[1], param[2],
 		  param[3]);
+	/* IDX is the lane now, which is what an LDS stack is laid out by. */
+	knod_bpf_emit_flat_scratch_init(priv, meta);
 	/* set frame pointer to 0 */
 	knod_sset32(&param[0], KNOD_AMDGPU_FRAME_POINTER_SREG);
 	knod_iset32(&param[1], 0);
@@ -5997,6 +6060,22 @@ static void knod_bpf_xdp_adjust_tail(struct knod_bpf_priv *priv,
  * unchanged against a stack that lives in scratch.  Returning the window
  * biased by the dword index is what lets the bodies keep indexing absolutely.
  */
+/* Where a stack byte lives in LDS.  The stack is the top max_stack_off bytes of
+ * the 512, laid out slot-major - every lane's dword N side by side - so the
+ * offset is the slot's distance from the bottom of what is used, times the
+ * workgroup.  The size check at finalisation keeps this under sixteen bits.
+ */
+static u16 knod_bpf_lds_off(struct knod_bpf_priv *priv,
+			    struct knod_insn_meta *meta, int off)
+{
+	if (off < priv->lds_stack_base)
+		pr_warn("knod_bpf: stack byte %d is below the tracked base %d (max_stack_off %d) at bpf insn %d code 0x%02x off %d\n",
+			off, priv->lds_stack_base,
+			priv->knod_prog ? priv->knod_prog->max_stack_off : -1,
+			meta->bpf_insn_idx, meta->insn.code, meta->insn.off);
+	return (off - priv->lds_stack_base) * knod_bpf_workgroups;
+}
+
 static struct amdgcn_param32 *knod_bpf_stack_win(struct knod_bpf_priv *priv,
 						 struct knod_insn_meta *meta,
 						 struct amdgcn_param32 *win,
@@ -6005,7 +6084,16 @@ static struct amdgcn_param32 *knod_bpf_stack_win(struct knod_bpf_priv *priv,
 	knod_vset32(&win[0], KNOD_AMDGPU_STACK_WIN_VREG0);
 	knod_vset32(&win[1], KNOD_AMDGPU_STACK_WIN_VREG1);
 
-	if (load) {
+	if (load && knod_bpf_stack_in_lds(priv)) {
+		struct amdgcn_param32 base;
+
+		knod_vset32(&base, KNOD_AMDGPU_LDS_BASE_VREG);
+		knod_emit(priv, meta, ds_read_b32, win[0], base,
+			  knod_bpf_lds_off(priv, meta, off & ~3));
+		knod_emit(priv, meta, ds_read_b32, win[1], base,
+			  knod_bpf_lds_off(priv, meta, (off & ~3) + 4));
+		knod_emit(priv, meta, s_waitcnt_lgkmcnt);
+	} else if (load) {
 		knod_emit(priv, meta, scratch_load_dword, win[0], off & ~3);
 		knod_emit(priv, meta, scratch_load_dword, win[1],
 			  (off & ~3) + 4);
@@ -6019,6 +6107,17 @@ static void knod_bpf_stack_win_flush(struct knod_bpf_priv *priv,
 				     struct knod_insn_meta *meta,
 				     struct amdgcn_param32 *win, int off)
 {
+	if (knod_bpf_stack_in_lds(priv)) {
+		struct amdgcn_param32 base;
+
+		knod_vset32(&base, KNOD_AMDGPU_LDS_BASE_VREG);
+		knod_emit(priv, meta, ds_write_b32, base, win[0],
+			  knod_bpf_lds_off(priv, meta, off & ~3));
+		knod_emit(priv, meta, ds_write_b32, base, win[1],
+			  knod_bpf_lds_off(priv, meta, (off & ~3) + 4));
+		return;
+	}
+
 	knod_emit(priv, meta, scratch_store_dword, win[0], off & ~3);
 	knod_emit(priv, meta, scratch_store_dword, win[1], (off & ~3) + 4);
 }
@@ -6037,7 +6136,7 @@ static void knod_bpf_load_size32(struct knod_bpf_priv *priv,
 {
 	struct amdgcn_param32 win[2];
 
-	if (cache == stack && knod_bpf_stack_in_scratch(priv))
+	if (cache == stack && knod_bpf_stack_in_mem(priv))
 		cache = knod_bpf_stack_win(priv, meta, win, off, true);
 
 	__knod_bpf_load_size32(priv, meta, dst, cache, size, off);
@@ -8335,7 +8434,7 @@ static void knod_bpf_store_cache_size(struct knod_bpf_priv *priv,
 {
 	struct amdgcn_param32 win[2];
 
-	if (cache != stack || !knod_bpf_stack_in_scratch(priv)) {
+	if (cache != stack || !knod_bpf_stack_in_mem(priv)) {
 		__knod_bpf_store_cache_size(priv, meta, src, cache, size, off);
 		return;
 	}
@@ -9684,8 +9783,49 @@ static int knod_bpf_jit(struct knod_dev *knodev,
 	if (ret)
 		return ret;
 
+	/* Fold the depth again from what will actually be emitted, on the same
+	 * test the emitter makes, now that every pointer state is final.  The
+	 * per-instruction folds above run inside the verifier hook, where a
+	 * store's pointer may not have been seen yet.
+	 */
+	list_for_each_entry(meta, &knod_prog->insns, l) {
+		int depth;
+
+		if (meta->ptr.type != PTR_TO_STACK)
+			continue;
+		switch (BPF_CLASS(meta->insn.code)) {
+		case BPF_LDX:
+			depth = meta->sreg.stack_off + meta->insn.off;
+			break;
+		case BPF_STX:
+		case BPF_ST:
+			depth = meta->dreg.stack_off + meta->insn.off;
+			break;
+		default:
+			continue;
+		}
+		if (knod_prog->max_stack_off > depth)
+			knod_prog->max_stack_off = depth;
+	}
 	knod_prog->max_stack_off = -knod_prog->max_stack_off;
 	knod_prog->max_stack_off = ALIGN(knod_prog->max_stack_off, 4);
+	knod_prog->lds_bytes = 0;
+	priv->lds_stack_base = 512 - knod_prog->max_stack_off;
+	if (knod_bpf_stack_in_lds(priv)) {
+		/* One slot past the top: the window moves two dwords at a
+		 * time, so the highest slot's partner lands just beyond the
+		 * stack, and it has to be a real, distinct place - not the
+		 * wrap of a sixteen-bit offset back onto slot zero.
+		 */
+		knod_prog->lds_bytes = ALIGN((knod_prog->max_stack_off + 4) *
+					     knod_bpf_workgroups, 1024);
+		if (knod_prog->lds_bytes > priv->knod->lds_size) {
+			pr_warn("knod_bpf: %d bytes of stack a lane times %u lanes is %u, more LDS than a workgroup has; use a smaller workgroup or stack_cache=0\n",
+				knod_prog->max_stack_off, knod_bpf_workgroups,
+				knod_prog->lds_bytes);
+			return -E2BIG;
+		}
+	}
 	knod_prog->max_packet_off = ALIGN(knod_prog->max_packet_off, 4);
 	/* NOTE:
 	 * packet is accessed with packet_off + size
@@ -12212,10 +12352,17 @@ static int knod_stats_show(struct seq_file *s, void *unused)
 	/* What is in force, and when that is not what was asked for, say so:
 	 * reporting only the effective value turns a refusal into a mystery.
 	 */
+	seq_printf(s, "lds_per_wg:          %u\n", priv->knod->lds_size);
+	seq_printf(s, "stack_bytes:         %d per lane\n",
+		   priv->knod_prog ? priv->knod_prog->max_stack_off : 0);
+	seq_printf(s, "lds_alloc:           %u\n",
+		   priv->lds_bytes[READ_ONCE(priv->active_idx)]);
 	seq_printf(s, "stack_cache:         %s%s\n",
+		   knod_bpf_stack_in_lds(priv) ? "lds" :
 		   knod_bpf_stack_in_scratch(priv) ? "scratch" : "vgpr",
-		   !knod_bpf_stack_cache && !knod_bpf_stack_in_scratch(priv) ?
-		   " (scratch asked for and refused)" : "");
+		   knod_bpf_stack_cache != KNOD_STACK_VGPR &&
+		   !knod_bpf_stack_in_mem(priv) ?
+		   " (asked for and refused)" : "");
 	seq_printf(s, "mcpu:                gfx%u%u%u\n",
 		   gfx / 10000, (gfx / 100) % 100, gfx % 100);
 	seq_printf(s, "jit_engine:          %s\n",

--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.h
@@ -59,12 +59,11 @@
 #define KNOD_BPF_EXPIRE_DEFAULT		10
 #define KNOD_BPF_EXPIRE_MIN		1
 #define KNOD_BPF_EXPIRE_MAX		1000
-/* Nothing reaches LDS - not the JIT, not a blob routine - so none is asked for.
- * What it would cost is workgroups per CU: at 256 work-items the registers
- * already allow only one and LDS would be free to take, but at 64 they allow
- * four and taking all the LDS cuts that back to one.
+/* LDS is asked for only when the stack lives there (stack_cache=2), sized per
+ * program from max_stack_off.  What it costs is workgroups per CU: at 256
+ * work-items the registers already allow only one and LDS is free to take,
+ * but at 64 they allow four and taking all the LDS cuts that back to one.
  */
-#define KNOD_BPF_LDS_SIZE		0
 #define QUEUE_SIZE_DGPU			8192
 #define QUEUE_SIZE_IGPU			2048
 #define KNOD_MAX_BDS			(KNOD_BPF_BACKLOGS_MAX / KNOD_SPSC_MAX)
@@ -394,6 +393,11 @@ struct knod_prog {
 	unsigned int prog_len;
 	unsigned int __prog_alloc_len;
 	int max_stack_off;
+	/* What the dispatch asks for in LDS when the stack lives there:
+	 * max_stack_off per lane, times the workgroup, rounded to what the
+	 * hardware allocates in.  Zero in every other mode.
+	 */
+	u32 lds_bytes;
 	int max_packet_off;
 
 	struct knod_insn_meta *meta;
@@ -524,6 +528,10 @@ struct knod_bpf_priv {
 	struct knod_dev *knodev;
 	struct net_device *dev;
 	struct knod_prog *knod_prog;
+	/* Set while a program is being emitted, for the LDS stack's offsets:
+	 * where its top max_stack_off bytes begin.
+	 */
+	int lds_stack_base;
 	/* retained pass IR for debugfs insn dump */
 	struct knod_prog *pass_knod_prog;
 	struct bpf_prog *prog;
@@ -547,6 +555,8 @@ struct knod_bpf_priv {
 	u32 pass_prog_size;
 	/* descriptor + live shader bytes per kernel slot */
 	u32 kernel_image_len[2];
+	/* What each slot's kernel wants in LDS, published with the slot. */
+	u32 lds_bytes[2];
 	/* knod->kernels[] slot the GPU dispatches */
 	int active_idx;
 	/* knod->kernels[] slot holding the pass kernel */


### PR DESCRIPTION
One commit, no blob half — the routines carry no numbers of their own and the
ABI stays at 10.

## A third place for the stack

`stack_cache=2` keeps the BPF stack in LDS. Like scratch (`0`) it frees v128
upwards; unlike scratch it is on the CU, with no memory round trip, and it is
sized to what the program actually uses rather than the whole 512 bytes — LDS is
64 KB per workgroup, 256 lanes of full stack would be twice that, and kondor's
stack is a fraction of it.

Laid out slot-major, every lane's dword N side by side, so a wave reading one
slot reads consecutive dwords and no two lanes share a bank — the interleave the
scratch hardware does on its own, done by hand. A lane's base is its workitem id
times four, computed once **after** the prologue extracts the id; the entry point
still has garbage there, which the first draft found out.

## Measured

gfx1100, wg=256, blob engine, all three in the same geometry:

| | throughput | latency | ns/lane | vs registers |
|---|---|---|---|---|
| registers | **57.46 Mpps** | 190 µs | 16.2 | — |
| **LDS** | **51.32 Mpps** | 278 µs | 18.5 | −10.7% |
| scratch | 44.85 Mpps | 339 µs | 22.2 | −21.9% |

LDS beats scratch by 14%. Both lose to registers, which puts a number on what
freeing 128 VGPRs costs: about a tenth. Whatever takes those registers has to
earn more than that back. Scratch stays in the tree for now, for comparison on
other parts.

Worth knowing: the stack traffic is not small. On gfx1030 scratch had cost 1.5%
and it looked as if kondor barely touched its stack; that run was memory-bound
elsewhere (pkt_cache off, wg=128) and hid it. Here the cost is 88 µs a dispatch
for LDS, 149 µs for scratch. The window helper waits on `lgkmcnt(0)` after every
load, which also drains any scalar load in flight — the likely next lever.

## What sizing from `max_stack_off` turned up

It was wrong. The verifier-hook folds took a register's stack offset but not the
instruction's, so `*(u64 *)(r10 - 8)` counted as depth zero — which is why a
value computed for as long as the JIT has existed was read by nothing. The depth
is now folded again at finalisation, on the same test the emitter makes
(`ptr.type == PTR_TO_STACK`, `stack_off + insn.off`), once every pointer state is
final.

And the window helpers move two dwords at a time, so the top slot's partner lands
four bytes past the stack. One slot more is allocated so that it is a real,
distinct place and not — when LDS is exactly full — the sixteen-bit offset
wrapped back onto slot zero.

## Limits and plumbing

The cap comes from the topology (`lds_size_in_kb`) rather than a constant. It is
the same 64 KB in CU and WGP mode — per the RDNA3 ISA the mode decides where a
workgroup's allocation sits within the WGP's 128 KB, not how much it may take —
and the size is aligned to the 1 KB block the hardware hands LDS out in. A
program that will not fit is refused at load with the arithmetic in the message.

The size is published per kernel slot, beside `kernel_image_len`, and a dispatch
reads its code and its LDS from the same `active_idx`; with the double-buffered
kernel swap, a single value could hand the running kernel the *next* program's
size, and if that were smaller the running one would overflow.

gfx10 is wired the same way — the DS encodings are byte-checked against
`llvm-mc` for both — but has not been run yet; only gfx1100 has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsGojnqMrsfjEwh5cre56M