### PR TITLE
drm/amdkfd: knod: let the shader code buffer be cached

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/kfd_knod.c
+++ b/drivers/gpu/drm/amd/amdkfd/kfd_knod.c
@@ -1300,7 +1300,6 @@ static int knod_alloc_ctx_init(struct knod *knod, int id, void **doorbell,
 
 	knod->kernels[0] = knod_alloc_mem(knod, PAGE_SIZE << 10,
 				      KFD_IOC_ALLOC_MEM_FLAGS_VRAM |
-				      KFD_IOC_ALLOC_MEM_FLAGS_COHERENT |
 				      KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE |
 				      KFD_IOC_ALLOC_MEM_FLAGS_EXECUTABLE);
 	if (IS_ERR(knod->kernels[0])) {
@@ -1322,7 +1321,6 @@ static int knod_alloc_ctx_init(struct knod *knod, int id, void **doorbell,
 	 */
 	knod->kernels[1] = knod_alloc_mem(knod, PAGE_SIZE << 10,
 					  KFD_IOC_ALLOC_MEM_FLAGS_VRAM |
-					  KFD_IOC_ALLOC_MEM_FLAGS_COHERENT |
 					  KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE |
 					  KFD_IOC_ALLOC_MEM_FLAGS_EXECUTABLE);
 	if (IS_ERR(knod->kernels[1])) {


### PR DESCRIPTION
One commit, no blob half — the ABI is unchanged.

## The code BO was uncached

The two dispatch-slot BOs holding the JIT'd machine code asked for `COHERENT`,
which `gmc_v11_0_get_vm_pte()` turns into `MTYPE_UC`: every instruction the
command processor fetched went past L2 to memory.

Nothing needs the flag. The code a wave runs is read inside a dispatch, and every
dispatch opens with a system-scope acquire that the command processor turns into
a GL2 invalidate — so a slot rewritten between dispatches is seen, the same
mechanism the cached maps (#38) and packet buffer (#40) already rely on. The
kernel swap writes the inactive slot and flips `active_idx`, so the new code is
always read by a *later* dispatch, whose acquire has already run.

The instruction cache is a separate matter the prologue already handles with
`s_icache_inv`, and never depended on this flag — `MTYPE` is about the data
caches, not the SQC I$.

## What keeps COHERENT, and why

| BO | reader | behind a dispatch's acquire? |
|---|---|---|
| **code** (`kernels[0..1]`) | the wave | **yes** — removed here |
| AQL ring | CP, to read the dispatch packet | no (the acquire is *in* that packet) |
| queue descriptor | CP, for rptr/wptr and scratch | no |
| completion signal | host, polled for completion | no (GPU→host, no acquire) |
| SDMA control | SDMA engine / host poll | no |

Only the code BO is read by the shader from within a dispatch, so only it is
covered. The rest are control structures the CP reads to set a dispatch up or the
host polls for completion, and they stay coherent.

Tested on gfx1100: first program load after boot and the double-buffered swap
under live traffic both run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsGojnqMrsfjEwh5cre56M