### PR TITLE
drm/amdkfd: knod: drop the now-unused knod_alignbit32

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -4576,16 +4576,6 @@ static void knod_xor32(struct knod_bpf_priv *priv,
 	knod_emit(priv, meta, v_xor_b32_e32, dst, src0, src1);
 }
 
-static void knod_alignbit32(struct knod_bpf_priv *priv,
-			   struct knod_insn_meta *meta,
-			   struct amdgcn_param32 dst,
-			   struct amdgcn_param32 src0,
-			   struct amdgcn_param32 src1,
-			   struct amdgcn_param32 src2)
-{
-	knod_emit(priv, meta, v_alignbit_b32, dst, src0, src1, src2);
-}
-
 static void knod_bfe32(struct knod_bpf_priv *priv,
 			   struct knod_insn_meta *meta,
 			   struct amdgcn_param32 dst,


### PR DESCRIPTION
`knod_alignbit32`'s only callers were in the kernel emitter removed in #48
(blob-only conversion). The helper was left behind and warns under
`-Werror=unused-function`:

```
knod_bpf.c:4579:13: warning: 'knod_alignbit32' defined but not used
```

The GFX10 unaligned packet loads that once used it take the byte-load path now.
No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)