### PR TITLE
drm/amdkfd: knod: make XDP_PASS work on bnxt

### DIFF
--- a/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
+++ b/drivers/gpu/drm/amd/amdkfd/knod/knod_bpf.c
@@ -536,7 +536,12 @@ static unsigned int knod_bpf_active_rxq_count(struct net_device *netdev)
 	if (!nr_rxq)
 		nr_rxq = netdev->num_rx_queues;
 
-	return min_t(unsigned int, nr_rxq, KNOD_SPSC_MAX);
+	/* Also cap by CPU count: a percpu map keeps one instance per work and
+	 * aggregates per CPU, so more works than CPUs has nowhere to report the
+	 * excess.  A NIC can have far more rx queues (bnxt: 80+) than either.
+	 */
+	nr_rxq = min_t(unsigned int, nr_rxq, KNOD_SPSC_MAX);
+	return min_t(unsigned int, nr_rxq, num_possible_cpus());
 }
 
 static void knod_bpf_fill_dispatch(struct knod_bpf_priv *priv,

--- a/drivers/net/ethernet/broadcom/bnxt/bnxt_xdp.c
+++ b/drivers/net/ethernet/broadcom/bnxt/bnxt_xdp.c
@@ -693,8 +693,9 @@ int bnxt_rx_offload_act_handler(struct bnxt_napi *bnapi, int budget)
 {
 	struct bnxt_tx_ring_info *txr = bnapi->tx_ring[0];
 	struct bnxt_rx_ring_info *rxr = bnapi->rx_ring;
+	struct spsc_pass_bd pass[NAPI_POLL_WEIGHT];
 	struct spsc_bd *bds[NAPI_POLL_WEIGHT];
-	u32 tx_avail, cnt, i, nxmit = 0;
+	u32 tx_avail, cnt, i, nxmit = 0, pass_cnt = 0;
 	struct knod_dev *knodev;
 	struct knod_work_priv *wpriv;
 	struct napi_struct *napi;
@@ -715,15 +716,16 @@ int bnxt_rx_offload_act_handler(struct bnxt_napi *bnapi, int budget)
 	if (!napi)
 		return 0;
 
+	/* Release only what there is room to act on, but always fall through
+	 * to the drain below: a re-armed poll with no new bds still has to
+	 * deliver d2h copies that have since landed (otherwise a PASS'd packet
+	 * waits for the next RX event - one-second ping latency at low rates).
+	 */
 	tx_avail = bnxt_tx_avail(bp, txr);
 	cnt = min_t(u32, NAPI_POLL_WEIGHT, tx_avail);
 	cnt = min_t(u32, cnt, budget);
-	if (!cnt)
-		return 0;
-
-	spsc_release(&wpriv->spsc_bds, (void **)bds, cnt, &cnt);
-	if (!cnt)
-		return 0;
+	if (cnt)
+		spsc_release(&wpriv->spsc_bds, (void **)bds, cnt, &cnt);
 
 	for (i = 0; i < cnt; i++) {
 		switch (bds[i]->act) {
@@ -737,15 +739,30 @@ int bnxt_rx_offload_act_handler(struct bnxt_napi *bnapi, int budget)
 					   bds[i]->netmem);
 			nxmit++;
 			break;
+		case XDP_PASS:
+			/* Hand to the common device->host delivery: batch here
+			 * and flush to knod_d2h_copy after the loop.  The source
+			 * page is recycled by knod_d2h_drain once the copy has
+			 * landed, so it is NOT recycled here.
+			 */
+			pass[pass_cnt].netmem = bds[i]->netmem;
+			pass[pass_cnt].page_idx = bds[i]->page_idx;
+			pass[pass_cnt].off = bds[i]->off;
+			pass[pass_cnt].len = bds[i]->len;
+			pass_cnt++;
+			break;
 		case XDP_ABORTED:
 			fallthrough;
 		case XDP_DROP:
 			fallthrough;
-		case XDP_PASS:
-			fallthrough;
 		case XDP_REDIRECT:
-			fallthrough;
+			page_pool_recycle_direct_netmem(rxr->page_pool,
+							bds[i]->netmem);
+			this_cpu_inc(knodev->stats->tx_dropped);
+			break;
 		default:
+			pr_warn_ratelimited("bnxt knod: invalid bd->act=0x%llx q%d, treating as DROP\n",
+					    bds[i]->act, bnapi->index);
 			page_pool_recycle_direct_netmem(rxr->page_pool,
 							bds[i]->netmem);
 			this_cpu_inc(knodev->stats->tx_dropped);
@@ -757,7 +774,12 @@ stop_release:
 		wmb();
 		bnxt_db_write(bp, &txr->tx_db, txr->tx_prod);
 	}
-	spsc_release_commit(&wpriv->spsc_bds, i);
+	if (cnt)
+		spsc_release_commit(&wpriv->spsc_bds, i);
+
+	/* Issue the device->host copies for this batch's XDP_PASS bds. */
+	if (pass_cnt)
+		knod_d2h_copy(knodev, bnapi->index, pass, pass_cnt);
 
 	/*
 	 * Device->host delivery: drain the framework pending ring for this NIC


### PR DESCRIPTION
Make XDP_PASS work on bnxt (validated with feature=none and bpf; ping RTT
back to sub-ms from a stale-module 1s red herring).

**1. Deliver XDP_PASS on bnxt, and drain regardless of new bds** (`bnxt_xdp.c`)
- `bnxt_rx_offload_act_handler` folded XDP_PASS into the drop/recycle default,
  so passed packets were recycled and counted as `tx_dropped`. Now batched and
  handed to `knod_d2h_copy`; the source page is recycled by `knod_d2h_drain`
  after the copy lands.
- The drain sat behind the `cnt==0` early returns, so a re-armed poll with no
  new bds skipped it and a landed d2h copy waited for the next RX event
  (one-second ping latency at low rates). It now always runs.
- Unknown verdicts warn instead of being silently dropped.

**2. Cap the work count by CPU** (`knod_bpf.c`)
- `nr_works = min(real_num_rx_queues, KNOD_SPSC_MAX)` ignored CPU count; a NIC
  with far more rx queues than CPUs (bnxt: 80+) tripped the percpu-map
  "nowhere to report the rest" refusal. Now also capped by `num_possible_cpus()`.

Note: ipsec is still XDP/BPF-only on bnxt (no ipsec feature flag / verdict
cases wired) - out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsGojnqMrsfjEwh5cre56M
